### PR TITLE
[codex] add pkg.pr.new preview publishing

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -8,9 +8,7 @@ on:
     tags-ignore:
       - "**"
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   publish:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -8,7 +8,9 @@ on:
     tags-ignore:
       - "**"
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   publish:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,29 @@
+name: Preview Package
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm release:check
+      - run: pnpm exec pkg-pr-new publish ./packages/vite --bin --packageManager=pnpm

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@changesets/changelog-git": "catalog:",
     "@changesets/cli": "catalog:",
+    "pkg-pr-new": "^0.0.75",
     "vite-doctor": "workspace:*",
     "vite-plus": "catalog:"
   },

--- a/packages/core/src/internal/scan-session.ts
+++ b/packages/core/src/internal/scan-session.ts
@@ -23,7 +23,7 @@ import { createHelpers } from "./doctor-helpers.js";
 import { VERSION, nativeMatch, sha256 } from "./utils.js";
 
 const DEFAULT_CONFIG: DoctorConfig = {
-  cache: { dir: ".vue-doctor/cache" },
+  cache: { dir: ".vite-doctor/cache" },
 };
 
 class MemoryRuleCache implements RuleCache {
@@ -41,7 +41,7 @@ class PersistentRuleCache extends MemoryRuleCache {
 
   constructor(root: string, config: DoctorConfig) {
     super();
-    this.dir = resolve(root, config.cache?.dir ?? ".vue-doctor/cache");
+    this.dir = resolve(root, config.cache?.dir ?? ".vite-doctor/cache");
   }
 
   override get<T = unknown>(key: string): T | undefined {
@@ -164,7 +164,7 @@ export async function runPhase(
 }
 
 export function cleanCache(root = process.cwd(), config?: DoctorConfig): void {
-  const dir = resolve(root, config?.cache?.dir ?? ".vue-doctor/cache");
+  const dir = resolve(root, config?.cache?.dir ?? ".vite-doctor/cache");
   if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
 }
 

--- a/packages/core/tests/plumbing.test.ts
+++ b/packages/core/tests/plumbing.test.ts
@@ -572,6 +572,25 @@ test("runDoctor accepts an already-loaded config object", async () => {
   );
 });
 
+test("persistent cache defaults to Vite Doctor directory", async () => {
+  await withFixture(
+    {
+      "src/app.ts": "const message = 'hello'\n",
+    },
+    async (root) => {
+      await runDoctor({
+        root,
+        framework: "vue",
+        cache: true,
+        extensions: [pluginWith(reportProgramRule)],
+      });
+
+      expect(existsSync(join(root, ".vite-doctor/cache"))).toBe(true);
+      expect(existsSync(join(root, ".vue-doctor"))).toBe(false);
+    },
+  );
+});
+
 async function withFixture(files: Record<string, string>, run: (root: string) => Promise<void>) {
   const root = await mkdtemp(join(tmpdir(), "vue-doctor-core-"));
   try {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -21,6 +21,7 @@
   "types": "./dist/index.d.mts",
   "exports": {
     ".": "./dist/index.mjs",
+    "./cli": "./dist/cli.mjs",
     "./module": "./dist/module.mjs",
     "./rules": "./dist/rules/index.mjs",
     "./package.json": "./package.json"
@@ -70,7 +71,16 @@
     "node": ">=22.20.0"
   },
   "inlinedDependencies": {
+    "c12": "4.0.0-beta.5",
+    "confbox": "0.2.4",
     "defu": "6.1.7",
-    "nostics": "0.1.0"
+    "destr": "2.0.5",
+    "dotenv": "17.4.2",
+    "exsolve": "1.0.8",
+    "giget": "3.2.0",
+    "jiti": "2.7.0",
+    "nostics": "0.1.0",
+    "pkg-types": "2.3.1",
+    "rc9": "3.0.1"
   }
 }

--- a/packages/nuxt/src/cli.ts
+++ b/packages/nuxt/src/cli.ts
@@ -111,12 +111,9 @@ function addScanCommand(cli: ReturnType<typeof cac>, name: "scan" | "check", cwd
     .option("--baseline <file>", "Baseline file.")
     .option("--format <format>", "Machine output: json or sarif.")
     .action(async (path = ".", options) => {
-      const runOptions: DoctorRunOptions = {};
-      applyDoctorOptions(runOptions, options);
       const root = resolve(cwd, path);
-      if (options.config || options.trustedConfig) {
-        runOptions.config = await loadDoctorConfig({ cwd: root });
-      }
+      const runOptions: DoctorRunOptions = { config: await loadDoctorConfig({ cwd: root }) };
+      applyDoctorOptions(runOptions, options);
       const result = await runNuxtDoctor({ ...runOptions, cwd, root: path });
       return shouldFail(result, runOptions) ? 1 : 0;
     });

--- a/packages/nuxt/src/cli.ts
+++ b/packages/nuxt/src/cli.ts
@@ -27,11 +27,16 @@ export interface RunNuxtDoctorOptions extends DoctorRunOptions {
 
 export async function runNuxtDoctor(options: RunNuxtDoctorOptions = {}) {
   const { cwd, extraRulePacks, ...runOptions } = options;
+  const root = resolve(cwd ?? process.cwd(), runOptions.root ?? ".");
   const result = await runDoctor({
     ...runOptions,
+    config: {
+      ...runOptions.config,
+      cache: { dir: ".nuxt/doctor/cache", ...runOptions.config?.cache },
+    },
     framework: "nuxt",
     extensions: [...nuxtDoctorExtensions(extraRulePacks), ...(runOptions.extensions ?? [])],
-    root: resolve(cwd ?? process.cwd(), runOptions.root ?? "."),
+    root,
   });
   process.stdout.write(createReport(result, runOptions.format));
   return result;

--- a/packages/nuxt/src/cli.ts
+++ b/packages/nuxt/src/cli.ts
@@ -45,8 +45,8 @@ export async function runNuxtDoctor(options: RunNuxtDoctorOptions = {}) {
 export async function main(args = process.argv.slice(2), cwd = process.cwd()): Promise<number> {
   let exitCode = 0;
   const cli = cac("nuxt-doctor");
-  addScanCommand(cli, "scan", cwd, (code) => (exitCode = code));
-  addScanCommand(cli, "check", cwd, (code) => (exitCode = code));
+  addScanCommand(cli, "scan", cwd);
+  addScanCommand(cli, "check", cwd);
   cli
     .command("rules", "List Nuxt Doctor rules.")
     .option("--format <format>", "Machine output: json or sarif.")
@@ -81,12 +81,7 @@ export async function main(args = process.argv.slice(2), cwd = process.cwd()): P
   }
 }
 
-function addScanCommand(
-  cli: ReturnType<typeof cac>,
-  name: "scan" | "check",
-  cwd: string,
-  setExitCode: (code: number) => void,
-) {
+function addScanCommand(cli: ReturnType<typeof cac>, name: "scan" | "check", cwd: string) {
   cli
     .command(`${name} [path]`, `Run ${name} diagnostics.`)
     .option("--config", "Load trusted doctor.config.*.")
@@ -123,7 +118,7 @@ function addScanCommand(
         runOptions.config = await loadDoctorConfig({ cwd: root });
       }
       const result = await runNuxtDoctor({ ...runOptions, cwd, root: path });
-      setExitCode(shouldFail(result, runOptions) ? 1 : 0);
+      return shouldFail(result, runOptions) ? 1 : 0;
     });
 }
 

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -6,7 +6,6 @@ import type {
   NuxtModuleSource,
   RulePack,
 } from "@vue-doctor/core";
-import { parseRunArgs, runNuxtDoctor } from "./cli.js";
 export type { NuxtDoctorManifest } from "@vue-doctor/core";
 
 export interface NuxtDoctorModuleOptions {
@@ -76,33 +75,6 @@ export default async function nuxtDoctorModule(options: NuxtDoctorModuleOptions 
   nuxt.hook?.("close", async () => {
     await writeManifest(nuxt, evidence);
   });
-
-  nuxt.options.cli ??= {};
-  nuxt.options.cli.commands ??= {};
-  nuxt.options.cli.commands.doctor = {
-    description: "Run Nuxt Doctor",
-    async run(ctx: any) {
-      const extraRulePacks = await collectNuxtDoctorRulePacks(nuxt);
-      const extraExtensions = await collectNuxtDoctorExtensions(nuxt);
-      const argv = Array.isArray(ctx?.rawArgs) ? ctx.rawArgs : [];
-      const { path, options } = parseRunArgs(argv);
-      const result = await runNuxtDoctor({
-        ...options,
-        extends: options.extends ?? nuxt.options.doctor?.extends,
-        extensions: [
-          ...(nuxt.options.doctor?.extensions ?? []),
-          ...extraExtensions,
-          ...(options.extensions ?? []),
-        ],
-        root: path === "." ? (ctx?.cwd ?? nuxt.options.rootDir) : path,
-        cwd: ctx?.cwd ?? nuxt.options.rootDir,
-        extraRulePacks,
-      });
-      if (result.summary.blocker || result.summary.error) process.exitCode = 1;
-      if (options.maxWarnings !== undefined && result.summary.warn > options.maxWarnings)
-        process.exitCode = 1;
-    },
-  };
 }
 
 export async function collectNuxtDoctorRulePacks(nuxt: any): Promise<RulePack[]> {

--- a/packages/nuxt/src/rules/nuxt/async-data-handler-pure.ts
+++ b/packages/nuxt/src/rules/nuxt/async-data-handler-pure.ts
@@ -1,7 +1,9 @@
 import { AnyNode, createRule, report } from "./shared.js";
 import {
+  asyncDataRuleOptions,
   collectReplayableSideEffects,
   getAsyncDataCall,
+  isReadonlyPath,
   replayableSeverity,
 } from "./async-data.js";
 
@@ -19,8 +21,15 @@ export const asyncDataHandlerPure = createRule({
       ScriptNode(node: AnyNode) {
         const call = getAsyncDataCall(ctx, node);
         if (!call?.handler) return;
+        const options = asyncDataRuleOptions(ctx);
         for (const effect of collectReplayableSideEffects(ctx, call.handler)) {
           const isMutatingFetch = effect.kind === "mutating-fetch";
+          if (
+            isMutatingFetch &&
+            effect.method === "POST" &&
+            (call.readonlyMarked || isReadonlyPath(effect.path ?? call.path, options))
+          )
+            continue;
           report(
             ctx,
             effect.node,

--- a/packages/nuxt/src/rules/nuxt/async-data.ts
+++ b/packages/nuxt/src/rules/nuxt/async-data.ts
@@ -1,10 +1,11 @@
 import type { RuleContext } from "@vue-doctor/core";
 import {
   findAncestor,
+  resolveLocalCalleeName,
   sourceForNode,
   walkScriptLocal,
   type AnyNode,
-} from "../../../../core/src/rule-authoring.js";
+} from "./shared.js";
 
 export const ASYNC_DATA_COMPOSABLES = new Set([
   "useFetch",
@@ -60,6 +61,7 @@ export interface SideEffectMatch {
   kind: "mutating-fetch" | "toast" | "navigation" | "refresh" | "store-write" | "analytics";
   confidence: ReplayableFindingConfidence;
   method?: string | null;
+  path?: string | null;
 }
 
 export function asyncDataRuleOptions(ctx: RuleContext): AsyncDataRuleOptions {
@@ -75,7 +77,7 @@ export function replayableSeverity(
 
 export function getAsyncDataCall(ctx: RuleContext, node: AnyNode): AsyncDataCall | null {
   if (!ctx.helpers.isCall(node)) return null;
-  const name = ctx.helpers.getCalleeName(node);
+  const name = resolveLocalCalleeName(ctx, node);
   if (!name || !ASYNC_DATA_COMPOSABLES.has(name)) return null;
   const options = getAsyncDataOptions(name, node);
   return {
@@ -195,7 +197,13 @@ export function collectReplayableSideEffects(ctx: RuleContext, root: AnyNode): S
     if (callee === "$fetch") {
       const method = resolveHttpMethod(getObjectPropertyValue(getFetchOptions(node), "method"));
       if (method && WRITE_METHODS.has(method)) {
-        matches.push({ node, kind: "mutating-fetch", method, confidence: "proven-write" });
+        matches.push({
+          node,
+          kind: "mutating-fetch",
+          method,
+          path: getStaticString(node.arguments?.[0]),
+          confidence: "proven-write",
+        });
       }
       return;
     }

--- a/packages/nuxt/src/rules/nuxt/no-composable-after-await.ts
+++ b/packages/nuxt/src/rules/nuxt/no-composable-after-await.ts
@@ -2,11 +2,14 @@ import {
   AnyNode,
   NUXT_AUTO_IMPORTS,
   createRule,
+  findAncestor,
   hasPriorAwaitInSameExecutionScope,
   isClientOnlyPath,
   isNuxtRuntimeFile,
   isTopLevelVueScriptSetupCall,
+  nearestFunctionOrProgram,
   report,
+  resolveLocalCalleeName,
 } from "./shared.js";
 import { createNuxtRuntimeEvidence } from "./evidence.js";
 
@@ -25,9 +28,13 @@ export const noComposableAfterAwait = createRule({
     const composables = new Set([...NUXT_AUTO_IMPORTS, "useSeoMeta", "useHead", "useHeadSafe"]);
     return {
       ScriptNode(node: AnyNode) {
-        const name = ctx.helpers.getCalleeName(node);
+        const name = resolveLocalCalleeName(ctx, node);
         if (!name || !composables.has(name) || !hasPriorAwaitInSameExecutionScope(node)) return;
         if (isTopLevelVueScriptSetupCall(ctx, node)) return;
+        if (name === "navigateTo" && isReturnedFromRouteMiddleware(ctx.file.relativePath, node))
+          return;
+        if (name === "navigateTo" && isVueComponentFunctionNavigation(ctx.file.relativePath, node))
+          return;
         if (evidence.isClientCallable(node)) return;
         if (ctx.helpers.isClientOnlyExecutionContext(node, ctx.file.text)) return;
         report(
@@ -43,3 +50,22 @@ export const noComposableAfterAwait = createRule({
     };
   },
 });
+
+function isReturnedFromRouteMiddleware(path: string, node: AnyNode): boolean {
+  if (!/app\/middleware\/.+\.[cm]?[jt]s$/.test(path)) return false;
+  const returned = findAncestor(node, (parent) => parent.type === "ReturnStatement") !== null;
+  if (!returned) return false;
+  return (
+    findAncestor(
+      node,
+      (parent) =>
+        parent.type === "CallExpression" && parent.callee?.name === "defineNuxtRouteMiddleware",
+    ) !== null
+  );
+}
+
+function isVueComponentFunctionNavigation(path: string, node: AnyNode): boolean {
+  if (!path.endsWith(".vue")) return false;
+  const fn = nearestFunctionOrProgram(node);
+  return Boolean(fn && fn.type !== "Program");
+}

--- a/packages/nuxt/src/rules/nuxt/shared.ts
+++ b/packages/nuxt/src/rules/nuxt/shared.ts
@@ -94,16 +94,36 @@ export function report(
 export function hasPriorAwaitInSameExecutionScope(node: AnyNode): boolean {
   const scope = nearestFunctionOrProgram(node);
   if (!scope) return false;
-  let seenTarget = false;
   let seenAwait = false;
+  const targetStart = node.start ?? node.range?.[0] ?? 0;
   walkScriptLocal(scope.body ?? scope, (current) => {
-    if (current === node) {
-      seenTarget = true;
-      return;
-    }
-    if (!seenTarget && current.type === "AwaitExpression") seenAwait = true;
+    if (seenAwait || current.type !== "AwaitExpression") return;
+    const currentStart = current.start ?? current.range?.[0] ?? Number.POSITIVE_INFINITY;
+    if (currentStart >= targetStart) return;
+    if (nearestFunctionOrProgram(current) !== scope) return;
+    seenAwait = true;
   });
   return seenAwait;
+}
+
+export function resolveLocalCalleeName(ctx: RuleContext, node: AnyNode): string | null {
+  const name = ctx.helpers.getCalleeName(node);
+  if (!name) return null;
+  return getLocalAliasMap(ctx).get(name) ?? name;
+}
+
+function getLocalAliasMap(ctx: RuleContext): Map<string, string> {
+  const key = `nuxt:local-callee-aliases:${ctx.file.hash}`;
+  const cached = ctx.cache.get<Map<string, string>>(key);
+  if (cached) return cached;
+  const aliases = new Map<string, string>();
+  walkScriptLocal(ctx.file.scriptAst, (node) => {
+    if (node.type !== "VariableDeclarator" || node.id?.type !== "Identifier") return;
+    const initName = ctx.helpers.getCalleeName({ callee: node.init });
+    if (initName && NUXT_AUTO_IMPORTS.has(initName)) aliases.set(node.id.name, initName);
+  });
+  ctx.cache.set(key, aliases);
+  return aliases;
 }
 
 export function includeTrailingNewline(text: string, end: number) {

--- a/packages/nuxt/tests/nuxt-modern-rules.test.ts
+++ b/packages/nuxt/tests/nuxt-modern-rules.test.ts
@@ -672,6 +672,54 @@ useAsyncData('settings', async () => {
   expect(result.diagnostics[0]?.severity).toBe("warn");
 });
 
+test("async data handler purity respects readonly POST markers", async () => {
+  const result = await runProjectFixture({
+    framework: "nuxt",
+    rules: [asyncDataHandlerPure],
+    config: {
+      rules: {
+        "nuxt/async-data-handler-pure": ["warn", { readonlyPaths: ["/api/cube/**"] }],
+      },
+    },
+    files: {
+      "app/pages/search.vue": `<script setup lang="ts">
+useAsyncData('marked', () => $fetch('/api/search', {
+  method: 'POST',
+  body,
+}), {
+  meta: { readonly: true },
+})
+useAsyncData('configured', () => $fetch('/api/cube/query', {
+  method: 'POST',
+  body,
+}))
+useAsyncData('write', () => $fetch('/api/settings', {
+  method: 'POST',
+  body,
+}))
+useAsyncData('delete', () => $fetch('/api/settings', {
+  method: 'DELETE',
+}))
+</script>`,
+    },
+  });
+
+  expect(result.diagnostics.map((item) => item.severity)).toEqual(["warn"]);
+
+  const deleteResult = await runRuleFixture({
+    rule: asyncDataHandlerPure,
+    framework: "nuxt",
+    files: {
+      "app/pages/settings.vue": `<script setup lang="ts">
+useAsyncData('delete', () => $fetch('/api/settings', {
+  method: 'DELETE',
+}))
+</script>`,
+    },
+  });
+  expect(deleteResult.diagnostics.map((item) => item.severity)).toEqual(["error"]);
+});
+
 test("async data handler purity narrows store assignment evidence to local Pinia stores", async () => {
   const result = await runRuleFixture({
     rule: asyncDataHandlerPure,
@@ -1064,6 +1112,58 @@ test("composables after await in custom async functions still report", async () 
   expect(result.diagnostics[0]?.ruleId).toBe("nuxt/context/no-composable-after-await");
 });
 
+test("composable aliases after await still report", async () => {
+  const result = await runRuleFixture({
+    rule: noComposableAfterAwait,
+    framework: "nuxt",
+    files: {
+      "app/composables/useThing.ts": `export async function useThing() {
+  const loadFetch = useFetch
+  await load()
+  return loadFetch('/api/thing')
+}`,
+    },
+  });
+
+  expect(result.diagnostics[0]?.ruleId).toBe("nuxt/context/no-composable-after-await");
+});
+
+test("nested async helpers do not count as prior awaits", async () => {
+  const result = await runRuleFixture({
+    rule: noComposableAfterAwait,
+    framework: "nuxt",
+    files: {
+      "app/composables/useThing.ts": `export function useThing() {
+  async function loadLater() {
+    await load()
+  }
+  const data = useAsyncData('thing', () => $fetch('/api/thing'))
+  return { data, loadLater }
+}`,
+    },
+  });
+
+  expect(result.diagnostics).toHaveLength(0);
+});
+
+test("route middleware may return navigateTo after awaited session loading", async () => {
+  const result = await runRuleFixture({
+    rule: noComposableAfterAwait,
+    framework: "nuxt",
+    files: {
+      "app/middleware/auth.ts": `export default defineNuxtRouteMiddleware(async () => {
+  const { loggedIn, fetchSession } = useUserSession()
+  if (!loggedIn.value) {
+    await fetchSession()
+    return navigateTo('/')
+  }
+})`,
+    },
+  });
+
+  expect(result.diagnostics).toHaveLength(0);
+});
+
 test("navigateTo after await in client-callable handlers is ignored", async () => {
   const result = await runRuleFixture({
     rule: noComposableAfterAwait,
@@ -1093,6 +1193,30 @@ async function logout() {
   navigateTo('/login')
 }
 const items = [{ label: 'Logout', onClick: logout }]
+</script>`,
+    },
+  });
+
+  expect(result.diagnostics).toHaveLength(0);
+});
+
+test("navigateTo after await in component prop handlers is ignored", async () => {
+  const result = await runRuleFixture({
+    rule: noComposableAfterAwait,
+    framework: "nuxt",
+    files: {
+      "app/components/EditForm.vue": `<template>
+<ActionForm :action="save" :on-delete="remove" />
+</template>
+<script setup lang="ts">
+async function save() {
+  await persist()
+  await navigateTo('/items')
+}
+async function remove() {
+  await destroy()
+  navigateTo('/items')
+}
 </script>`,
     },
   });

--- a/packages/nuxt/tests/nuxt-modern-rules.test.ts
+++ b/packages/nuxt/tests/nuxt-modern-rules.test.ts
@@ -2697,6 +2697,22 @@ test("nuxt-doctor exits 1 for errors and 0 for warnings unless max warnings is z
   );
 }, 30000);
 
+test("nuxt-doctor stores cache inside Nuxt build directory", async () => {
+  await withFixture(
+    {
+      "app/pages/index.vue": `<script setup>const width = window.innerWidth</script>`,
+    },
+    {},
+    async (root) => {
+      await main([root, "--rules", "nuxt/hydration/no-browser-global-in-universal-code"]);
+
+      expect(existsSync(join(root, ".nuxt/doctor/cache"))).toBe(true);
+      expect(existsSync(join(root, ".vite-doctor"))).toBe(false);
+      expect(existsSync(join(root, ".vue-doctor"))).toBe(false);
+    },
+  );
+}, 30000);
+
 async function withFixture(
   files: Record<string, string>,
   dependencies: Record<string, string>,

--- a/packages/nuxt/tsdown.config.ts
+++ b/packages/nuxt/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   clean: true,
   dts: true,
-  entry: ["src/index.ts", "src/module.ts", "src/rules/index.ts"],
+  entry: ["src/index.ts", "src/cli.ts", "src/module.ts", "src/rules/index.ts"],
   exports: true,
   format: ["esm"],
 });

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -42,19 +42,19 @@
     "check": "vp check"
   },
   "dependencies": {
-    "@vue-doctor/core": "workspace:*",
     "cac": "^6.7.14",
     "consola": "^3.4.2",
-    "nitro-doctor": "workspace:*",
-    "nuxt-doctor": "workspace:*",
     "oxc-parser": "catalog:",
-    "pathe": "^2.0.3",
-    "vue-doctor": "workspace:*"
+    "pathe": "^2.0.3"
   },
   "devDependencies": {
+    "@vue-doctor/core": "workspace:*",
+    "nitro-doctor": "workspace:*",
+    "nuxt-doctor": "workspace:*",
     "tsdown": "catalog:",
     "vite": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vue-doctor": "workspace:*"
   },
   "peerDependencies": {
     "vite": "*"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -16,6 +16,7 @@
     "directory": "packages/vite"
   },
   "bin": {
+    "nuxt-doctor": "./dist/nuxt-cli.mjs",
     "vite-doctor": "./dist/cli.mjs"
   },
   "files": [
@@ -27,6 +28,7 @@
     ".": "./dist/index.mjs",
     "./cli": "./dist/cli.mjs",
     "./nuxt": "./dist/nuxt.mjs",
+    "./nuxt-cli": "./dist/nuxt-cli.mjs",
     "./plugin": "./dist/plugin.mjs",
     "./rules": "./dist/rules.mjs",
     "./package.json": "./package.json"

--- a/packages/vite/src/doctor.ts
+++ b/packages/vite/src/doctor.ts
@@ -50,6 +50,13 @@ export async function runViteDoctor(options: DoctorRunOptions) {
   const extensions = await viteDoctorExtensions(options);
   return runDoctor({
     ...options,
+    config: {
+      ...options.config,
+      cache:
+        framework === "nuxt"
+          ? { dir: ".nuxt/doctor/cache", ...options.config?.cache }
+          : options.config?.cache,
+    },
     framework,
     extensions: [...extensions, ...(options.extensions ?? [])],
   });

--- a/packages/vite/src/nuxt-cli.ts
+++ b/packages/vite/src/nuxt-cli.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { main } from "nuxt-doctor/cli";
+
+const code = await main();
+if (code !== 0) {
+  process.exitCode = code;
+  throw new Error(`Nuxt Doctor failed with exit code ${code}`);
+}

--- a/packages/vite/tests/cli.test.ts
+++ b/packages/vite/tests/cli.test.ts
@@ -137,6 +137,30 @@ useRoute();
   );
 });
 
+test("Nuxt framework scans store cache inside Nuxt build directory", async () => {
+  await withFixture(
+    {
+      "package.json": JSON.stringify({ dependencies: { nuxt: "^4.0.0" } }),
+      "app/pages/index.vue": `<script setup lang="ts">const width = window.innerWidth</script>`,
+    },
+    async (root) => {
+      await runCli(
+        [
+          ".",
+          "--framework",
+          "nuxt",
+          "--rules",
+          "nuxt/hydration/no-browser-global-in-universal-code",
+        ],
+        root,
+      );
+
+      expect(existsSync(join(root, ".nuxt/doctor/cache"))).toBe(true);
+      expect(existsSync(join(root, ".vite-doctor"))).toBe(false);
+    },
+  );
+});
+
 test("framework override can enable Nuxt rules without Nuxt dependencies", async () => {
   await withFixture(
     {

--- a/packages/vite/tsdown.config.ts
+++ b/packages/vite/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   clean: true,
   deps: {
-    alwaysBundle: [/^@vue-doctor\/core/],
+    alwaysBundle: [/^@vue-doctor\/core/, /^nitro-doctor/, /^nuxt-doctor/, /^vue-doctor/],
     onlyBundle: false,
   },
   dts: true,

--- a/packages/vite/tsdown.config.ts
+++ b/packages/vite/tsdown.config.ts
@@ -7,7 +7,14 @@ export default defineConfig({
     onlyBundle: false,
   },
   dts: true,
-  entry: ["src/index.ts", "src/cli.ts", "src/plugin.ts", "src/nuxt.ts", "src/rules.ts"],
+  entry: [
+    "src/index.ts",
+    "src/cli.ts",
+    "src/nuxt-cli.ts",
+    "src/plugin.ts",
+    "src/nuxt.ts",
+    "src/rules.ts",
+  ],
   exports: true,
   format: ["esm"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.31.0(@types/node@25.6.2)
+      pkg-pr-new:
+        specifier: ^0.0.75
+        version: 0.0.75
       vite-doctor:
         specifier: workspace:*
         version: link:packages/vite
@@ -7752,6 +7755,10 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -17928,6 +17935,8 @@ snapshots:
       pngjs: 7.0.0
 
   pkce-challenge@5.0.1: {}
+
+  pkg-pr-new@0.0.75: {}
 
   pkg-types@1.3.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,21 +337,12 @@ importers:
 
   packages/vite:
     dependencies:
-      '@vue-doctor/core':
-        specifier: workspace:*
-        version: link:../core
       cac:
         specifier: ^6.7.14
         version: 6.7.14
       consola:
         specifier: ^3.4.2
         version: 3.4.2
-      nitro-doctor:
-        specifier: workspace:*
-        version: link:../nitro
-      nuxt-doctor:
-        specifier: workspace:*
-        version: link:../nuxt
       oxc-parser:
         specifier: 'catalog:'
         version: 0.129.0
@@ -361,16 +352,25 @@ importers:
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@latest
         version: '@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(typescript@6.0.3)(yaml@2.8.4)'
-      vue-doctor:
-        specifier: workspace:*
-        version: link:../vue
     devDependencies:
+      '@vue-doctor/core':
+        specifier: workspace:*
+        version: link:../core
+      nitro-doctor:
+        specifier: workspace:*
+        version: link:../nitro
+      nuxt-doctor:
+        specifier: workspace:*
+        version: link:../nuxt
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(typescript@6.0.3)
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.21(@opentelemetry/api@1.9.0)(@types/node@25.6.2)(@voidzero-dev/vite-plus-core@0.1.21(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(typescript@6.0.3)(yaml@2.8.4))(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.7.0)(terser@5.47.1)(typescript@6.0.3)(yaml@2.8.4)
+      vue-doctor:
+        specifier: workspace:*
+        version: link:../vue
 
   packages/vue:
     dependencies:


### PR DESCRIPTION
Adds a pkg.pr.new preview publishing workflow for vite-doctor so portal can test unreleased package builds before an alpha release.

The workflow installs from the lockfile, runs the release check, and publishes the vite-doctor package preview with binary-oriented install output enabled.