### PR TITLE
feat: prefer VueUse event listener cleanup

### DIFF
--- a/docs/rules/metadata.ts
+++ b/docs/rules/metadata.ts
@@ -1504,6 +1504,23 @@ export const ruleDocumentationMetadata = {
       },
     ],
   },
+  "vue/lifecycle/prefer-use-event-listener": {
+    description:
+      "Finds Vue scopes that manually pair DOM event listener setup and cleanup when VueUse is already available.",
+    why: "DOM listeners are lifecycle resources. Keeping setup and disposal behind a composable makes repeated watcher runs, component unmounts, and composable scope disposal harder to drift apart.",
+    recommendedReplacement:
+      "Use VueUse useEventListener() for DOM listeners. In watcher callbacks, keep the returned stop handle in watcher cleanup when each watcher run owns a fresh listener.",
+    examples: [
+      {
+        title: "Use VueUse for watcher-owned listeners",
+        language: "ts",
+        invalid:
+          "watch(active, (_value, _oldValue, onCleanup) => {\n  const el = document.querySelector('.target')\n  if (!el) return\n  const onEnd = () => el.classList.remove('active')\n  el.addEventListener('animationend', onEnd, { once: true })\n  onCleanup(() => el.removeEventListener('animationend', onEnd))\n})",
+        valid:
+          "watch(active, (_value, _oldValue, onCleanup) => {\n  const el = document.querySelector('.target')\n  if (!el) return\n  const stop = useEventListener(el, 'animationend', () => {\n    el.classList.remove('active')\n  }, { once: true })\n  onCleanup(stop)\n})",
+      },
+    ],
+  },
   "vue/reactivity/defineprops-watch-getter": {
     description:
       "Finds Vue reactivity code that can be written with a clearer framework-supported pattern.",

--- a/docs/rules/source.ts
+++ b/docs/rules/source.ts
@@ -514,7 +514,10 @@ function ruleUsefulLinks(rule: RuleDocument): RuleUsefulLink[] {
     add("VueUse useStorage", "https://vueuse.org/core/useStorage/");
   }
 
-  if (rule.id.includes("prefer-useevent-listener")) {
+  if (
+    rule.id.includes("prefer-useevent-listener") ||
+    rule.id.includes("prefer-use-event-listener")
+  ) {
     add("VueUse useEventListener", "https://vueuse.org/core/useeventlistener/");
   }
 

--- a/src/core/diagnostic-code-map.ts
+++ b/src/core/diagnostic-code-map.ts
@@ -37,6 +37,7 @@ export const allDoctorDiagnosticRegistry = defineDoctorDiagnostics([
   { code: "VUE0022", ruleId: "vue/template/html-button-has-type" },
   { code: "VUE0023", ruleId: "vue/template/prefer-same-name-prop-shorthand" },
   { code: "VUE0024", ruleId: "vue/template/prefer-true-attribute-shorthand" },
+  { code: "VUE0025", ruleId: "vue/lifecycle/prefer-use-event-listener" },
   { code: "VITE0001", ruleId: "vite/assets/no-dynamic-new-url" },
   { code: "VITE0002", ruleId: "vite/assets/no-public-src-import" },
   { code: "VITE0003", ruleId: "vite/assets/no-src-absolute-public-url" },

--- a/src/rule-packs/vue/diagnostics.ts
+++ b/src/rule-packs/vue/diagnostics.ts
@@ -25,6 +25,7 @@ export const vueDiagnosticRegistry = defineDoctorDiagnostics([
   { code: "VUE0022", ruleId: "vue/template/html-button-has-type" },
   { code: "VUE0023", ruleId: "vue/template/prefer-same-name-prop-shorthand" },
   { code: "VUE0024", ruleId: "vue/template/prefer-true-attribute-shorthand" },
+  { code: "VUE0025", ruleId: "vue/lifecycle/prefer-use-event-listener" },
 ]);
 
 export const diagnostics = vueDiagnosticRegistry.diagnostics;

--- a/src/rule-packs/vue/rules/vue/index.ts
+++ b/src/rule-packs/vue/rules/vue/index.ts
@@ -10,6 +10,7 @@ export { noSetupPropsDestructure } from "./no-setup-props-destructure.js";
 export { noAsyncWatchEffectAfterAwaitRead } from "./no-async-watch-effect-after-await-read.js";
 export { requireWatcherCleanup } from "./require-watcher-cleanup.js";
 export { requirePostFlushForDomWatch } from "./require-post-flush-for-dom-watch.js";
+export { preferUseEventListener } from "./prefer-use-event-listener.js";
 export { noMutationInOnUpdated } from "./no-mutation-in-on-updated.js";
 export { requireLifecycleCleanup } from "./require-lifecycle-cleanup.js";
 export { preferUseIdForStableIds } from "./prefer-use-id-for-stable-ids.js";
@@ -34,6 +35,7 @@ import { noSetupPropsDestructure } from "./no-setup-props-destructure.js";
 import { noAsyncWatchEffectAfterAwaitRead } from "./no-async-watch-effect-after-await-read.js";
 import { requireWatcherCleanup } from "./require-watcher-cleanup.js";
 import { requirePostFlushForDomWatch } from "./require-post-flush-for-dom-watch.js";
+import { preferUseEventListener } from "./prefer-use-event-listener.js";
 import { noMutationInOnUpdated } from "./no-mutation-in-on-updated.js";
 import { requireLifecycleCleanup } from "./require-lifecycle-cleanup.js";
 import { preferUseIdForStableIds } from "./prefer-use-id-for-stable-ids.js";
@@ -60,6 +62,7 @@ const rules = [
   noAsyncWatchEffectAfterAwaitRead,
   requireWatcherCleanup,
   requirePostFlushForDomWatch,
+  preferUseEventListener,
   noMutationInOnUpdated,
   requireLifecycleCleanup,
   preferUseIdForStableIds,

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -1,0 +1,159 @@
+import { AnyNode, bindingNames, createRule, report, walkScriptLocal } from "./shared.js";
+import type { RuleContext } from "../../../../core/index.js";
+
+const RULE_ID = "vue/lifecycle/prefer-use-event-listener";
+const WATCH_CALLBACK_CALLEES = new Set(["watch"]);
+const WATCH_EFFECT_CALLBACK_CALLEES = new Set([
+  "watchEffect",
+  "watchPostEffect",
+  "watchSyncEffect",
+]);
+const LIFECYCLE_CLEANUP_CALLEES = new Set(["onBeforeUnmount", "onScopeDispose", "onUnmounted"]);
+
+export const preferUseEventListener = createRule({
+  meta: {
+    id: RULE_ID,
+    title: "Prefer VueUse event listener cleanup",
+    category: "lifecycle",
+    severity: "warn",
+    fixable: "suggestion",
+    docsUrl: "https://vueuse.org/core/useeventlistener/",
+    requires: { script: true, vue: true },
+  },
+  create(ctx) {
+    if (!projectHasVueUse(ctx)) return;
+    if (ctx.project.framework === "nuxt" && !isNuxtVueRuntimePath(ctx.file.relativePath)) return;
+
+    return {
+      ScriptNode(node: AnyNode) {
+        if (!isAddEventListenerCall(node, ctx.helpers.getCalleeName(node))) return;
+        const owner = manualListenerOwner(node, ctx.file.text);
+        if (!owner) return;
+        if (nodeSource(owner, ctx.file.text).includes("useEventListener")) return;
+
+        report(
+          ctx,
+          node,
+          RULE_ID,
+          "warn",
+          "lifecycle",
+          "This Vue scope manually pairs addEventListener() with cleanup even though VueUse is available.",
+          "Use useEventListener() so listener disposal is bound to the Vue scope; keep the returned stop handle in watcher cleanup when the listener lifetime is per watcher run.",
+        );
+      },
+    };
+  },
+});
+
+function projectHasVueUse(ctx: RuleContext) {
+  const pkg = ctx.getJson<any>("package.json");
+  const deps = {
+    ...pkg?.dependencies,
+    ...pkg?.devDependencies,
+    ...pkg?.optionalDependencies,
+    ...pkg?.peerDependencies,
+  };
+  if (deps["@vueuse/core"] || deps["@vueuse/nuxt"]) return true;
+  return (ctx.project.nuxt?.modules ?? []).some((module) =>
+    ["@vueuse/core", "@vueuse/nuxt"].includes(module.name),
+  );
+}
+
+function manualListenerOwner(addCall: AnyNode, source: string) {
+  for (let current = addCall.__doctorParent; current; current = current.__doctorParent) {
+    if (!isFunctionLike(current) && current.type !== "Program") continue;
+
+    if (isFunctionLike(current)) {
+      const watcherCleanupNames = watcherCleanupCallees(current);
+      if (watcherCleanupNames && hasListenerCleanup(current, watcherCleanupNames, source))
+        return current;
+    }
+
+    if (hasListenerCleanup(current, LIFECYCLE_CLEANUP_CALLEES, source)) return current;
+  }
+
+  return null;
+}
+
+function watcherCleanupCallees(functionNode: AnyNode): Set<string> | null {
+  const call = functionNode.__doctorParent;
+  if (call?.type !== "CallExpression") return null;
+  const name = calleeName(call);
+  const args = call.arguments ?? [];
+
+  if (name && WATCH_CALLBACK_CALLEES.has(name) && args[1] === functionNode) {
+    return new Set(["onWatcherCleanup", ...bindingNames(functionNode.params?.[2])]);
+  }
+
+  if (name && WATCH_EFFECT_CALLBACK_CALLEES.has(name) && args[0] === functionNode) {
+    return new Set(["onWatcherCleanup", ...bindingNames(functionNode.params?.[0])]);
+  }
+
+  return null;
+}
+
+function hasListenerCleanup(scope: AnyNode, cleanupCallees: Set<string>, source: string) {
+  if (!cleanupCallees.size) return false;
+  let found = false;
+  walkScriptLocal(scope, (node) => {
+    if (found || node.type !== "CallExpression") return;
+    const name = calleeName(node);
+    if (!name || !matchesCallee(name, cleanupCallees)) return;
+    const cleanupSource = nodeSource(node.arguments?.[0] ?? node, source);
+    found =
+      cleanupSource.includes("removeEventListener") ||
+      nodeSource(scope, source).includes("removeEventListener");
+  });
+  return found;
+}
+
+function isAddEventListenerCall(node: AnyNode, name: string | null) {
+  return (
+    node.type === "CallExpression" && !!name && matchesCallee(name, new Set(["addEventListener"]))
+  );
+}
+
+function matchesCallee(name: string, callees: Set<string>) {
+  for (const callee of callees) {
+    if (name === callee || name.endsWith(`.${callee}`)) return true;
+  }
+  return false;
+}
+
+function calleeName(node: AnyNode): string | null {
+  return nodeName(node?.callee);
+}
+
+function nodeName(node: AnyNode): string | null {
+  if (!node) return null;
+  if (node.type === "Identifier") return node.name;
+  if (node.type === "Literal") return String(node.value);
+  if (node.type === "StaticMemberExpression" || node.type === "MemberExpression") {
+    const object = nodeName(node.object);
+    const property = nodeName(node.property);
+    return object && property ? `${object}.${property}` : (object ?? property);
+  }
+  return null;
+}
+
+function nodeSource(node: AnyNode, source: string) {
+  const start = node?.start ?? node?.range?.[0];
+  const end = node?.end ?? node?.range?.[1];
+  return typeof start === "number" && typeof end === "number" ? source.slice(start, end) : "";
+}
+
+function isFunctionLike(node: AnyNode) {
+  return ["ArrowFunctionExpression", "FunctionDeclaration", "FunctionExpression"].includes(
+    node?.type,
+  );
+}
+
+function isNuxtVueRuntimePath(path: string) {
+  if (
+    path.includes(".client.") ||
+    /\.(md|mdc|markdown)$/.test(path) ||
+    /^(content|server|app\/server|shared\/types|generated|app\/generated)\//.test(path)
+  )
+    return false;
+  return /^(app\/)?(components|composables|layouts|middleware|pages|plugins|utils)\//.test(path);
+}

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -169,5 +169,6 @@ function isNuxtVueRuntimePath(path: string) {
     /^(content|server|app\/server|shared\/types|generated|app\/generated)\//.test(path)
   )
     return false;
+  if (path === "app.vue" || path === "app/app.vue") return true;
   return /^(app\/)?(components|composables|layouts|middleware|pages|plugins|utils)\//.test(path);
 }

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -1,4 +1,4 @@
-import { AnyNode, bindingNames, createRule, report, walkScriptLocal } from "./shared.js";
+import { AnyNode, bindingNames, createRule, report } from "./shared.js";
 import type { RuleContext } from "../../../../core/index.js";
 
 const RULE_ID = "vue/lifecycle/prefer-use-event-listener";
@@ -95,14 +95,11 @@ function watcherCleanupCallees(functionNode: AnyNode): Set<string> | null {
 function hasListenerCleanup(scope: AnyNode, cleanupCallees: Set<string>, source: string) {
   if (!cleanupCallees.size) return false;
   let found = false;
-  walkScriptLocal(scope, (node) => {
+  walkScope(scope, (node) => {
     if (found || node.type !== "CallExpression") return;
     const name = calleeName(node);
     if (!name || !matchesCallee(name, cleanupCallees)) return;
-    const cleanupSource = nodeSource(node.arguments?.[0] ?? node, source);
-    found =
-      cleanupSource.includes("removeEventListener") ||
-      nodeSource(scope, source).includes("removeEventListener");
+    found = nodeSource(node.arguments?.[0], source).includes("removeEventListener");
   });
   return found;
 }
@@ -148,9 +145,26 @@ function isFunctionLike(node: AnyNode) {
   );
 }
 
+function walkScope(node: AnyNode, visit: (node: AnyNode) => void, root = node) {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const child of node) walkScope(child, visit, root);
+    return;
+  }
+  if (node !== root && isFunctionLike(node)) return;
+  if (typeof node.type === "string") visit(node);
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "__doctorParent") continue;
+    if (Array.isArray(value)) {
+      for (const child of value) walkScope(child, visit, root);
+    } else if (value && typeof value === "object") {
+      walkScope(value, visit, root);
+    }
+  }
+}
+
 function isNuxtVueRuntimePath(path: string) {
   if (
-    path.includes(".client.") ||
     /\.(md|mdc|markdown)$/.test(path) ||
     /^(content|server|app\/server|shared\/types|generated|app\/generated)\//.test(path)
   )

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -204,7 +204,7 @@ function sameListener(a: ListenerKey, b: ListenerKey) {
 
 function expressionKey(node: AnyNode, source: string) {
   if (!node) return "";
-  if (node.type === "Literal") return JSON.stringify(node.value);
+  if (node.type === "Literal" || node.type === "StringLiteral") return JSON.stringify(node.value);
   return nodeSource(node, source).replace(/\s+/g, " ").trim();
 }
 

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -98,7 +98,45 @@ function hasListenerCleanup(scope: AnyNode, cleanupCallees: Set<string>, source:
     if (found || node.type !== "CallExpression") return;
     const name = calleeName(node);
     if (!name || !matchesCallee(name, cleanupCallees)) return;
-    found = nodeSource(node.arguments?.[0], source).includes("removeEventListener");
+    found = hasListenerCleanupArgument(scope, node.arguments?.[0], source);
+  });
+  return found;
+}
+
+function hasListenerCleanupArgument(scope: AnyNode, argument: AnyNode, source: string) {
+  if (nodeSource(argument, source).includes("removeEventListener")) return true;
+  const referencedCleanup = referencedFunction(scope, argument);
+  return referencedCleanup ? hasRemoveEventListenerCall(referencedCleanup) : false;
+}
+
+function referencedFunction(scope: AnyNode, argument: AnyNode) {
+  const name = argument?.type === "Identifier" ? argument.name : null;
+  if (!name) return null;
+
+  let found: AnyNode = null;
+  walkScope(scope, (node) => {
+    if (found) return;
+    if (node.type === "FunctionDeclaration" && node.id?.name === name) {
+      found = node;
+      return;
+    }
+    if (
+      node.type === "VariableDeclarator" &&
+      node.id?.type === "Identifier" &&
+      node.id.name === name
+    ) {
+      found = isFunctionLike(node.init) ? node.init : null;
+    }
+  });
+  return found;
+}
+
+function hasRemoveEventListenerCall(scope: AnyNode) {
+  let found = false;
+  walkScope(scope, (node) => {
+    if (found || node.type !== "CallExpression") return;
+    const name = calleeName(node);
+    found = !!name && matchesCallee(name, new Set(["removeEventListener"]));
   });
   return found;
 }
@@ -150,8 +188,8 @@ function walkScope(node: AnyNode, visit: (node: AnyNode) => void, root = node) {
     for (const child of node) walkScope(child, visit, root);
     return;
   }
-  if (node !== root && isFunctionLike(node)) return;
   if (typeof node.type === "string") visit(node);
+  if (node !== root && isFunctionLike(node)) return;
   for (const [key, value] of Object.entries(node)) {
     if (key === "__doctorParent") continue;
     if (Array.isArray(value)) {

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -29,7 +29,6 @@ export const preferUseEventListener = createRule({
         if (!isAddEventListenerCall(node, ctx.helpers.getCalleeName(node))) return;
         const owner = manualListenerOwner(node, ctx.file.text);
         if (!owner) return;
-        if (nodeSource(owner, ctx.file.text).includes("useEventListener")) return;
 
         report(
           ctx,

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -1,4 +1,4 @@
-import { relative } from "pathe";
+import { relative, resolve } from "pathe";
 import { AnyNode, bindingNames, createRule, report } from "./shared.js";
 import type { RuleContext } from "../../../../core/index.js";
 
@@ -10,6 +10,12 @@ const WATCH_EFFECT_CALLBACK_CALLEES = new Set([
   "watchSyncEffect",
 ]);
 const LIFECYCLE_CLEANUP_CALLEES = new Set(["onBeforeUnmount", "onScopeDispose", "onUnmounted"]);
+const NUXT_CONFIG_FILES = [
+  "nuxt.config.ts",
+  "nuxt.config.js",
+  "nuxt.config.mjs",
+  "nuxt.config.mts",
+];
 
 export const preferUseEventListener = createRule({
   meta: {
@@ -60,16 +66,19 @@ function projectHasVueUse(ctx: RuleContext) {
 }
 
 function manualListenerOwner(addCall: AnyNode, source: string) {
+  const listener = listenerKey(addCall, "addEventListener", source);
+  if (!listener) return null;
+
   for (let current = addCall.__doctorParent; current; current = current.__doctorParent) {
     if (!isFunctionLike(current) && current.type !== "Program") continue;
 
     if (isFunctionLike(current)) {
       const watcherCleanupNames = watcherCleanupCallees(current);
-      if (watcherCleanupNames && hasListenerCleanup(current, watcherCleanupNames, source))
+      if (watcherCleanupNames && hasListenerCleanup(current, watcherCleanupNames, source, listener))
         return current;
     }
 
-    if (hasListenerCleanup(current, LIFECYCLE_CLEANUP_CALLEES, source)) return current;
+    if (hasListenerCleanup(current, LIFECYCLE_CLEANUP_CALLEES, source, listener)) return current;
   }
 
   return null;
@@ -92,22 +101,40 @@ function watcherCleanupCallees(functionNode: AnyNode): Set<string> | null {
   return null;
 }
 
-function hasListenerCleanup(scope: AnyNode, cleanupCallees: Set<string>, source: string) {
+function hasListenerCleanup(
+  scope: AnyNode,
+  cleanupCallees: Set<string>,
+  source: string,
+  listener: ListenerKey,
+) {
   if (!cleanupCallees.size) return false;
   let found = false;
   walkScope(scope, (node) => {
     if (found || node.type !== "CallExpression") return;
     const name = calleeName(node);
     if (!name || !matchesCallee(name, cleanupCallees)) return;
-    found = hasListenerCleanupArgument(scope, node.arguments?.[0], source);
+    found = hasListenerCleanupArgument(scope, node.arguments?.[0], source, listener);
   });
   return found;
 }
 
-function hasListenerCleanupArgument(scope: AnyNode, argument: AnyNode, source: string) {
-  if (nodeSource(argument, source).includes("removeEventListener")) return true;
+interface ListenerKey {
+  target: string;
+  event: string;
+  handler: string;
+}
+
+function hasListenerCleanupArgument(
+  scope: AnyNode,
+  argument: AnyNode,
+  source: string,
+  listener: ListenerKey,
+) {
+  if (hasRemoveEventListenerCall(argument, source, listener)) return true;
   const referencedCleanup = referencedFunction(scope, argument);
-  return referencedCleanup ? hasRemoveEventListenerCall(referencedCleanup) : false;
+  return referencedCleanup
+    ? hasRemoveEventListenerCall(referencedCleanup, source, listener)
+    : false;
 }
 
 function referencedFunction(scope: AnyNode, argument: AnyNode) {
@@ -132,14 +159,53 @@ function referencedFunction(scope: AnyNode, argument: AnyNode) {
   return found;
 }
 
-function hasRemoveEventListenerCall(scope: AnyNode) {
+function hasRemoveEventListenerCall(scope: AnyNode, source: string, listener: ListenerKey) {
   let found = false;
   walkScope(scope, (node) => {
     if (found || node.type !== "CallExpression") return;
-    const name = calleeName(node);
-    found = !!name && matchesCallee(name, new Set(["removeEventListener"]));
+    const cleanup = listenerKey(node, "removeEventListener", source);
+    found = !!cleanup && sameListener(cleanup, listener);
   });
   return found;
+}
+
+function listenerKey(
+  call: AnyNode,
+  method: "addEventListener" | "removeEventListener",
+  source: string,
+) {
+  const name = calleeName(call);
+  if (!name || !matchesCallee(name, new Set([method]))) return null;
+
+  const args = call.arguments ?? [];
+  const event = expressionKey(args[0], source);
+  const handler = expressionKey(args[1], source);
+  if (!event || !handler) return null;
+
+  return {
+    target: listenerTargetKey(call, method, source),
+    event,
+    handler,
+  };
+}
+
+function listenerTargetKey(call: AnyNode, method: string, source: string) {
+  const callee = call.callee;
+  if (callee?.type === "StaticMemberExpression" || callee?.type === "MemberExpression") {
+    const property = nodeName(callee.property);
+    if (property === method) return expressionKey(callee.object, source);
+  }
+  return "globalThis";
+}
+
+function sameListener(a: ListenerKey, b: ListenerKey) {
+  return a.target === b.target && a.event === b.event && a.handler === b.handler;
+}
+
+function expressionKey(node: AnyNode, source: string) {
+  if (!node) return "";
+  if (node.type === "Literal") return JSON.stringify(node.value);
+  return nodeSource(node, source).replace(/\s+/g, " ").trim();
 }
 
 function isAddEventListenerCall(node: AnyNode, name: string | null) {
@@ -224,9 +290,32 @@ function nuxtRuntimePathCandidates(ctx: RuleContext) {
 
 function nuxtRuntimeRoots(ctx: RuleContext) {
   const nuxt = ctx.project.nuxt;
-  return [nuxt?.appDir, ...(nuxt?.appRoots ?? []), ...(nuxt?.manifest?.appScanRoots ?? [])].filter(
-    (root): root is string => Boolean(root),
-  );
+  return [
+    nuxt?.appDir,
+    ...configuredNuxtSrcDirs(ctx),
+    ...(nuxt?.appRoots ?? []),
+    ...(nuxt?.manifest?.appScanRoots ?? []),
+  ].filter((root): root is string => Boolean(root));
+}
+
+function configuredNuxtSrcDirs(ctx: RuleContext) {
+  const dirs = new Set<string>();
+  for (const file of NUXT_CONFIG_FILES) {
+    const srcDir = readNuxtSrcDir(ctx, file);
+    if (srcDir) dirs.add(resolve(ctx.project.root, srcDir));
+  }
+  return dirs;
+}
+
+function readNuxtSrcDir(ctx: RuleContext, file: string) {
+  let text = "";
+  try {
+    text = ctx.getFileText(file);
+  } catch {
+    return null;
+  }
+  const match = text.match(/\bsrcDir\s*:\s*(['"`])([^'"`]+)\1/);
+  return match?.[2]?.replace(/\\/g, "/").replace(/\/$/, "") || null;
 }
 
 function relativeProjectPath(ctx: RuleContext, root: string) {

--- a/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
+++ b/src/rule-packs/vue/rules/vue/prefer-use-event-listener.ts
@@ -1,3 +1,4 @@
+import { relative } from "pathe";
 import { AnyNode, bindingNames, createRule, report } from "./shared.js";
 import type { RuleContext } from "../../../../core/index.js";
 
@@ -22,7 +23,7 @@ export const preferUseEventListener = createRule({
   },
   create(ctx) {
     if (!projectHasVueUse(ctx)) return;
-    if (ctx.project.framework === "nuxt" && !isNuxtVueRuntimePath(ctx.file.relativePath)) return;
+    if (ctx.project.framework === "nuxt" && !isNuxtVueRuntimePath(ctx)) return;
 
     return {
       ScriptNode(node: AnyNode) {
@@ -200,7 +201,45 @@ function walkScope(node: AnyNode, visit: (node: AnyNode) => void, root = node) {
   }
 }
 
-function isNuxtVueRuntimePath(path: string) {
+function isNuxtVueRuntimePath(ctx: RuleContext) {
+  for (const candidate of nuxtRuntimePathCandidates(ctx)) {
+    if (isNuxtVueRuntimeCandidate(candidate)) return true;
+  }
+  return false;
+}
+
+function nuxtRuntimePathCandidates(ctx: RuleContext) {
+  const path = toPosixPath(ctx.file.relativePath);
+  const candidates = new Set([path]);
+  for (const root of nuxtRuntimeRoots(ctx)) {
+    const relativeRoot = relativeProjectPath(ctx, root);
+    if (!relativeRoot || relativeRoot === ".") continue;
+    if (path === relativeRoot) candidates.add("");
+    else if (path.startsWith(`${relativeRoot}/`)) {
+      candidates.add(path.slice(relativeRoot.length + 1));
+    }
+  }
+  return candidates;
+}
+
+function nuxtRuntimeRoots(ctx: RuleContext) {
+  const nuxt = ctx.project.nuxt;
+  return [nuxt?.appDir, ...(nuxt?.appRoots ?? []), ...(nuxt?.manifest?.appScanRoots ?? [])].filter(
+    (root): root is string => Boolean(root),
+  );
+}
+
+function relativeProjectPath(ctx: RuleContext, root: string) {
+  const projectRoot = toPosixPath(ctx.project.root);
+  let normalized = toPosixPath(root);
+  if (normalized === projectRoot) return ".";
+  const projectPrefix = `${projectRoot}/`;
+  if (normalized.startsWith(projectPrefix)) normalized = normalized.slice(projectPrefix.length);
+  else normalized = toPosixPath(relative(ctx.project.root, normalized));
+  return normalized.replace(/^~\//, "app/").replace(/^@\//, "app/").replace(/^\.\//, "");
+}
+
+function isNuxtVueRuntimeCandidate(path: string) {
   if (
     /\.(md|mdc|markdown)$/.test(path) ||
     /^(content|server|app\/server|shared\/types|generated|app\/generated)\//.test(path)
@@ -208,4 +247,8 @@ function isNuxtVueRuntimePath(path: string) {
     return false;
   if (path === "app.vue" || path === "app/app.vue") return true;
   return /^(app\/)?(components|composables|layouts|middleware|pages|plugins|utils)\//.test(path);
+}
+
+function toPosixPath(path: string) {
+  return path.replace(/\\/g, "/");
 }

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -362,6 +362,56 @@ test("event listener rule detects lifecycle-scoped listener cleanup outside watc
   ]);
 });
 
+test("event listener rule resolves cleanup callbacks passed by reference", async () => {
+  const lifecycleCleanup = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/useViewport.ts": `export function useViewport() {
+  const onResize = () => {}
+
+  function cleanupResize() {
+    window.removeEventListener('resize', onResize)
+  }
+
+  onMounted(() => {
+    window.addEventListener('resize', onResize)
+  })
+
+  onUnmounted(cleanupResize)
+}`,
+    },
+  });
+  const watcherCleanup = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/useAnimation.ts": `watch(active, (_value, _oldValue, onCleanup) => {
+  const el = document.querySelector('.target')
+  if (!el)
+    return
+
+  const onAnimationEnd = () => el.classList.remove('active')
+  const cleanupAnimation = () => {
+    el.removeEventListener('animationend', onAnimationEnd)
+  }
+
+  el.addEventListener('animationend', onAnimationEnd, { once: true })
+  onCleanup(cleanupAnimation)
+})`,
+    },
+  });
+
+  expect(lifecycleCleanup.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+  expect(watcherCleanup.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+});
+
 test("event listener rule includes Nuxt client runtime files", async () => {
   const result = await runRuleFixture({
     rule: preferUseEventListener,

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -309,12 +309,49 @@ test("lifecycle cleanup rule allows utilities to return owned resources", async 
   expect(retained.diagnostics).toHaveLength(1);
 });
 
-test("event listener rule prefers VueUse for watcher-scoped listener cleanup", async () => {
-  const result = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
+const EVENT_LISTENER_RULE_ID = "vue/lifecycle/prefer-use-event-listener";
+const VUEUSE_DEPENDENCIES = { "@vueuse/core": "^14.0.0" };
+
+function expectEventListenerDiagnostics(
+  result: Awaited<ReturnType<typeof runRuleFixture>>,
+  count = 1,
+) {
+  expect(result.diagnostics.map((item) => item.ruleId)).toEqual(
+    Array.from({ length: count }, () => EVENT_LISTENER_RULE_ID),
+  );
+}
+
+function scriptSetupManualListener(eventName: string) {
+  const handler = `on${eventName[0]!.toUpperCase()}${eventName.slice(1)}`;
+  return `<script setup lang="ts">
+const ${handler} = () => {}
+
+onMounted(() => {
+  window.addEventListener('${eventName}', ${handler})
+})
+
+onUnmounted(() => {
+  window.removeEventListener('${eventName}', ${handler})
+})
+</script>`;
+}
+
+function nuxtPluginManualListener(eventName: string) {
+  const handler = `on${eventName[0]!.toUpperCase()}${eventName.slice(1)}`;
+  return `export default defineNuxtPlugin(() => {
+  const ${handler} = () => {}
+
+  window.addEventListener('${eventName}', ${handler})
+
+  onScopeDispose(() => {
+    window.removeEventListener('${eventName}', ${handler})
+  })
+})`;
+}
+
+test("event listener rule reports Vue-owned cleanup patterns", async () => {
+  const cases: Array<Record<string, string>> = [
+    {
       "src/useAnimation.ts": `watch(active, (_value, _oldValue, onCleanup) => {
   const el = document.querySelector('.target')
   if (!el)
@@ -329,45 +366,7 @@ test("event listener rule prefers VueUse for watcher-scoped listener cleanup", a
   })
 }, { flush: 'post' })`,
     },
-  });
-
-  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
-  expect(result.diagnostics[0]?.code).toBe("VUE0025");
-});
-
-test("event listener rule detects lifecycle-scoped listener cleanup outside watchers", async () => {
-  const result = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
-      "src/useViewport.ts": `export function useViewport() {
-  const onResize = () => {}
-
-  onMounted(() => {
-    window.addEventListener('resize', onResize)
-  })
-
-  onScopeDispose(() => {
-    window.removeEventListener('resize', onResize)
-  })
-}`,
-    },
-  });
-
-  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
-});
-
-test("event listener rule resolves cleanup callbacks passed by reference", async () => {
-  const lifecycleCleanup = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
+    {
       "src/useViewport.ts": `export function useViewport() {
   const onResize = () => {}
 
@@ -382,12 +381,7 @@ test("event listener rule resolves cleanup callbacks passed by reference", async
   onUnmounted(cleanupResize)
 }`,
     },
-  });
-  const watcherCleanup = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
+    {
       "src/useAnimation.ts": `watch(active, (_value, _oldValue, onCleanup) => {
   const el = document.querySelector('.target')
   if (!el)
@@ -402,120 +396,39 @@ test("event listener rule resolves cleanup callbacks passed by reference", async
   onCleanup(cleanupAnimation)
 })`,
     },
-  });
+  ];
+  const results = await Promise.all(
+    cases.map((files) =>
+      runRuleFixture({
+        rule: preferUseEventListener,
+        framework: "vue",
+        dependencies: VUEUSE_DEPENDENCIES,
+        files,
+      }),
+    ),
+  );
 
-  expect(lifecycleCleanup.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
-  expect(watcherCleanup.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
+  for (const result of results) expectEventListenerDiagnostics(result);
+  expect(results[0]?.diagnostics[0]?.code).toBe("VUE0025");
 });
 
-test("event listener rule includes Nuxt client runtime files", async () => {
+test("event listener rule honors Nuxt runtime roots", async () => {
   const result = await runRuleFixture({
     rule: preferUseEventListener,
     framework: "nuxt",
-    dependencies: { "@vueuse/core": "^14.0.0" },
+    dependencies: VUEUSE_DEPENDENCIES,
     files: {
-      "app/plugins/resize.client.ts": `export default defineNuxtPlugin(() => {
-  const onResize = () => {}
-
-  window.addEventListener('resize', onResize)
-
-  onScopeDispose(() => {
-    window.removeEventListener('resize', onResize)
-  })
-})`,
-    },
-  });
-
-  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
-});
-
-test("event listener rule includes Nuxt app root components", async () => {
-  const rootApp = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "nuxt",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
-      "app.vue": `<script setup lang="ts">
-const onResize = () => {}
-
-onMounted(() => {
-  window.addEventListener('resize', onResize)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('resize', onResize)
-})
-</script>`,
-    },
-  });
-  const nuxt4App = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "nuxt",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
-      "app/app.vue": `<script setup lang="ts">
-const onScroll = () => {}
-
-onMounted(() => {
-  window.addEventListener('scroll', onScroll)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('scroll', onScroll)
-})
-</script>`,
-    },
-  });
-
-  expect(rootApp.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
-  expect(nuxt4App.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
-});
-
-test("event listener rule honors Nuxt app roots for srcDir and layers", async () => {
-  const result = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "nuxt",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
+      "app/plugins/resize.client.ts": nuxtPluginManualListener("resize"),
+      "app.vue": scriptSetupManualListener("resize"),
+      "app/app.vue": scriptSetupManualListener("scroll"),
       "src/nuxt.config.ts": `export default defineNuxtConfig({})`,
-      "src/app/plugins/resize.client.ts": `export default defineNuxtPlugin(() => {
-  const onResize = () => {}
-
-  window.addEventListener('resize', onResize)
-
-  onScopeDispose(() => {
-    window.removeEventListener('resize', onResize)
-  })
-})`,
+      "src/app/plugins/focus.client.ts": nuxtPluginManualListener("focus"),
       "layers/admin/nuxt.config.ts": `export default defineNuxtConfig({})`,
-      "layers/admin/app/components/AdminWidget.vue": `<script setup lang="ts">
-const onScroll = () => {}
-
-onMounted(() => {
-  window.addEventListener('scroll', onScroll)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('scroll', onScroll)
-})
-</script>`,
+      "layers/admin/app/components/AdminWidget.vue": scriptSetupManualListener("keyup"),
     },
   });
 
-  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
+  expectEventListenerDiagnostics(result, 5);
 });
 
 test("event listener rule requires VueUse and existing manual cleanup evidence", async () => {
@@ -532,7 +445,7 @@ test("event listener rule requires VueUse and existing manual cleanup evidence",
   const withoutCleanup = await runRuleFixture({
     rule: preferUseEventListener,
     framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
+    dependencies: VUEUSE_DEPENDENCIES,
     files: {
       "src/useViewport.ts": `export function useViewport() {
   onMounted(() => window.addEventListener('resize', onResize))
@@ -542,7 +455,7 @@ test("event listener rule requires VueUse and existing manual cleanup evidence",
   const unrelatedCleanup = await runRuleFixture({
     rule: preferUseEventListener,
     framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
+    dependencies: VUEUSE_DEPENDENCIES,
     files: {
       "src/useViewport.ts": `export function useViewport() {
   onMounted(() => window.addEventListener('resize', onResize))
@@ -561,30 +474,10 @@ test("event listener rule requires VueUse and existing manual cleanup evidence",
 });
 
 test("event listener rule does not suppress manual cleanup when useEventListener is present", async () => {
-  const staleImport = await runRuleFixture({
+  const result = await runRuleFixture({
     rule: preferUseEventListener,
     framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
-    files: {
-      "src/App.vue": `<script setup lang="ts">
-import { useEventListener } from '@vueuse/core'
-
-const onScroll = () => {}
-
-onMounted(() => {
-  window.addEventListener('scroll', onScroll)
-})
-
-onUnmounted(() => {
-  window.removeEventListener('scroll', onScroll)
-})
-</script>`,
-    },
-  });
-  const mixedMigration = await runRuleFixture({
-    rule: preferUseEventListener,
-    framework: "vue",
-    dependencies: { "@vueuse/core": "^14.0.0" },
+    dependencies: VUEUSE_DEPENDENCIES,
     files: {
       "src/App.vue": `<script setup lang="ts">
 import { useEventListener } from '@vueuse/core'
@@ -605,12 +498,7 @@ onUnmounted(() => {
     },
   });
 
-  expect(staleImport.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
-  expect(mixedMigration.diagnostics.map((item) => item.ruleId)).toEqual([
-    "vue/lifecycle/prefer-use-event-listener",
-  ]);
+  expectEventListenerDiagnostics(result);
 });
 
 test("event listener rule is visible through global diagnostic reports", () => {

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -385,6 +385,52 @@ test("event listener rule includes Nuxt client runtime files", async () => {
   ]);
 });
 
+test("event listener rule includes Nuxt app root components", async () => {
+  const rootApp = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "nuxt",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "app.vue": `<script setup lang="ts">
+const onResize = () => {}
+
+onMounted(() => {
+  window.addEventListener('resize', onResize)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', onResize)
+})
+</script>`,
+    },
+  });
+  const nuxt4App = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "nuxt",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "app/app.vue": `<script setup lang="ts">
+const onScroll = () => {}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll)
+})
+</script>`,
+    },
+  });
+
+  expect(rootApp.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+  expect(nuxt4App.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+});
+
 test("event listener rule requires VueUse and existing manual cleanup evidence", async () => {
   const withoutVueUse = await runRuleFixture({
     rule: preferUseEventListener,

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -418,10 +418,10 @@ test("event listener rule honors Nuxt runtime roots", async () => {
     framework: "nuxt",
     dependencies: VUEUSE_DEPENDENCIES,
     files: {
+      "nuxt.config.ts": `export default defineNuxtConfig({ srcDir: 'src' })`,
       "app/plugins/resize.client.ts": nuxtPluginManualListener("resize"),
       "app.vue": scriptSetupManualListener("resize"),
       "app/app.vue": scriptSetupManualListener("scroll"),
-      "src/nuxt.config.ts": `export default defineNuxtConfig({})`,
       "src/app/plugins/focus.client.ts": nuxtPluginManualListener("focus"),
       "layers/admin/nuxt.config.ts": `export default defineNuxtConfig({})`,
       "layers/admin/app/components/AdminWidget.vue": scriptSetupManualListener("keyup"),
@@ -467,10 +467,31 @@ test("event listener rule requires VueUse and existing manual cleanup evidence",
 }`,
     },
   });
+  const partialCleanup = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: VUEUSE_DEPENDENCIES,
+    files: {
+      "src/useViewport.ts": `export function useViewport() {
+  const onOffline = () => {}
+  const onResize = () => {}
+
+  onMounted(() => {
+    window.addEventListener('offline', onOffline, { once: true })
+    window.addEventListener('resize', onResize)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener('resize', onResize)
+  })
+}`,
+    },
+  });
 
   expect(withoutVueUse.diagnostics).toHaveLength(0);
   expect(withoutCleanup.diagnostics).toHaveLength(0);
   expect(unrelatedCleanup.diagnostics).toHaveLength(0);
+  expectEventListenerDiagnostics(partialCleanup);
 });
 
 test("event listener rule does not suppress manual cleanup when useEventListener is present", async () => {

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -9,6 +9,7 @@ import {
   preferTypeProps,
   noUntranslatedText,
   noUnusedTranslations,
+  preferUseEventListener,
   requireLifecycleCleanup,
   requirePostFlushForDomWatch,
 } from "../../../src/rule-packs/vue/rules/vue/index.ts";
@@ -300,6 +301,102 @@ test("lifecycle cleanup rule allows utilities to return owned resources", async 
 
   expect(returned.diagnostics).toHaveLength(0);
   expect(retained.diagnostics).toHaveLength(1);
+});
+
+test("event listener rule prefers VueUse for watcher-scoped listener cleanup", async () => {
+  const result = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/useAnimation.ts": `watch(active, (_value, _oldValue, onCleanup) => {
+  const el = document.querySelector('.target')
+  if (!el)
+    return
+
+  const onAnimationEnd = () => el.classList.remove('active')
+  el.addEventListener('animationend', onAnimationEnd, { once: true })
+
+  onCleanup(() => {
+    el.removeEventListener('animationend', onAnimationEnd)
+    el.classList.remove('active')
+  })
+}, { flush: 'post' })`,
+    },
+  });
+
+  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+  expect(result.diagnostics[0]?.code).toBe("VUE0025");
+});
+
+test("event listener rule detects lifecycle-scoped listener cleanup outside watchers", async () => {
+  const result = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/useViewport.ts": `export function useViewport() {
+  const onResize = () => {}
+
+  onMounted(() => {
+    window.addEventListener('resize', onResize)
+  })
+
+  onScopeDispose(() => {
+    window.removeEventListener('resize', onResize)
+  })
+}`,
+    },
+  });
+
+  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+});
+
+test("event listener rule requires VueUse and existing manual cleanup evidence", async () => {
+  const withoutVueUse = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    files: {
+      "src/useViewport.ts": `export function useViewport() {
+  onMounted(() => window.addEventListener('resize', onResize))
+  onUnmounted(() => window.removeEventListener('resize', onResize))
+}`,
+    },
+  });
+  const withoutCleanup = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/useViewport.ts": `export function useViewport() {
+  onMounted(() => window.addEventListener('resize', onResize))
+}`,
+    },
+  });
+
+  expect(withoutVueUse.diagnostics).toHaveLength(0);
+  expect(withoutCleanup.diagnostics).toHaveLength(0);
+});
+
+test("event listener rule ignores scopes already using useEventListener", async () => {
+  const result = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/useViewport.ts": `export function useViewport() {
+  useEventListener(window, 'resize', onResize)
+  onMounted(() => window.addEventListener('scroll', onScroll))
+  onUnmounted(() => window.removeEventListener('scroll', onScroll))
+}`,
+    },
+  });
+
+  expect(result.diagnostics).toHaveLength(0);
 });
 
 test("vue SSR rules are skipped for plain SPA projects", async () => {

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -473,21 +473,57 @@ test("event listener rule requires VueUse and existing manual cleanup evidence",
   expect(unrelatedCleanup.diagnostics).toHaveLength(0);
 });
 
-test("event listener rule ignores scopes already using useEventListener", async () => {
-  const result = await runRuleFixture({
+test("event listener rule does not suppress manual cleanup when useEventListener is present", async () => {
+  const staleImport = await runRuleFixture({
     rule: preferUseEventListener,
     framework: "vue",
     dependencies: { "@vueuse/core": "^14.0.0" },
     files: {
-      "src/useViewport.ts": `export function useViewport() {
-  useEventListener(window, 'resize', onResize)
-  onMounted(() => window.addEventListener('scroll', onScroll))
-  onUnmounted(() => window.removeEventListener('scroll', onScroll))
-}`,
+      "src/App.vue": `<script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
+
+const onScroll = () => {}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll)
+})
+</script>`,
+    },
+  });
+  const mixedMigration = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/App.vue": `<script setup lang="ts">
+import { useEventListener } from '@vueuse/core'
+
+const onResize = () => {}
+const onScroll = () => {}
+
+useEventListener(window, 'resize', onResize)
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll)
+})
+</script>`,
     },
   });
 
-  expect(result.diagnostics).toHaveLength(0);
+  expect(staleImport.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+  expect(mixedMigration.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
 });
 
 test("event listener rule is visible through global diagnostic reports", () => {

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vite-plus/test";
+import { vueRulePack } from "../../../src/rule-packs/vue/index.ts";
 import {
   definePropsWatchGetter,
   noRefAsOperand,
@@ -13,7 +14,12 @@ import {
   requireLifecycleCleanup,
   requirePostFlushForDomWatch,
 } from "../../../src/rule-packs/vue/rules/vue/index.ts";
-import { allDiagnostics, createRule } from "../../../src/core/index.ts";
+import {
+  allDiagnostics,
+  createRule,
+  createRulesReport,
+  explainRule,
+} from "../../../src/core/index.ts";
 import {
   runNuxtAppRuleFixture,
   runNuxtManifestRuleFixture,
@@ -356,6 +362,29 @@ test("event listener rule detects lifecycle-scoped listener cleanup outside watc
   ]);
 });
 
+test("event listener rule includes Nuxt client runtime files", async () => {
+  const result = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "nuxt",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "app/plugins/resize.client.ts": `export default defineNuxtPlugin(() => {
+  const onResize = () => {}
+
+  window.addEventListener('resize', onResize)
+
+  onScopeDispose(() => {
+    window.removeEventListener('resize', onResize)
+  })
+})`,
+    },
+  });
+
+  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+});
+
 test("event listener rule requires VueUse and existing manual cleanup evidence", async () => {
   const withoutVueUse = await runRuleFixture({
     rule: preferUseEventListener,
@@ -377,9 +406,25 @@ test("event listener rule requires VueUse and existing manual cleanup evidence",
 }`,
     },
   });
+  const unrelatedCleanup = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "vue",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/useViewport.ts": `export function useViewport() {
+  onMounted(() => window.addEventListener('resize', onResize))
+  onUnmounted(noop)
+
+  function cleanupScroll() {
+    window.removeEventListener('scroll', onScroll)
+  }
+}`,
+    },
+  });
 
   expect(withoutVueUse.diagnostics).toHaveLength(0);
   expect(withoutCleanup.diagnostics).toHaveLength(0);
+  expect(unrelatedCleanup.diagnostics).toHaveLength(0);
 });
 
 test("event listener rule ignores scopes already using useEventListener", async () => {
@@ -397,6 +442,17 @@ test("event listener rule ignores scopes already using useEventListener", async 
   });
 
   expect(result.diagnostics).toHaveLength(0);
+});
+
+test("event listener rule is visible through global diagnostic reports", () => {
+  const rules = JSON.parse(createRulesReport([vueRulePack], "json"));
+  const rule = rules.rules.find(
+    (item: any) => item.id === "vue/lifecycle/prefer-use-event-listener",
+  );
+  const explanation = JSON.parse(explainRule([vueRulePack], "VUE0025", "json"));
+
+  expect(rule?.diagnosticCodes).toEqual(["VUE0025"]);
+  expect(explanation.id).toBe("vue/lifecycle/prefer-use-event-listener");
 });
 
 test("vue SSR rules are skipped for plain SPA projects", async () => {

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -481,6 +481,43 @@ onUnmounted(() => {
   ]);
 });
 
+test("event listener rule honors Nuxt app roots for srcDir and layers", async () => {
+  const result = await runRuleFixture({
+    rule: preferUseEventListener,
+    framework: "nuxt",
+    dependencies: { "@vueuse/core": "^14.0.0" },
+    files: {
+      "src/nuxt.config.ts": `export default defineNuxtConfig({})`,
+      "src/app/plugins/resize.client.ts": `export default defineNuxtPlugin(() => {
+  const onResize = () => {}
+
+  window.addEventListener('resize', onResize)
+
+  onScopeDispose(() => {
+    window.removeEventListener('resize', onResize)
+  })
+})`,
+      "layers/admin/nuxt.config.ts": `export default defineNuxtConfig({})`,
+      "layers/admin/app/components/AdminWidget.vue": `<script setup lang="ts">
+const onScroll = () => {}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', onScroll)
+})
+</script>`,
+    },
+  });
+
+  expect(result.diagnostics.map((item) => item.ruleId)).toEqual([
+    "vue/lifecycle/prefer-use-event-listener",
+    "vue/lifecycle/prefer-use-event-listener",
+  ]);
+});
+
 test("event listener rule requires VueUse and existing manual cleanup evidence", async () => {
   const withoutVueUse = await runRuleFixture({
     rule: preferUseEventListener,

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -482,7 +482,7 @@ test("event listener rule requires VueUse and existing manual cleanup evidence",
   })
 
   onUnmounted(() => {
-    window.removeEventListener('resize', onResize)
+    window.removeEventListener("resize", onResize)
   })
 }`,
     },


### PR DESCRIPTION
Adds a Vue Rule Pack diagnostic for manually paired DOM event listener setup and cleanup when VueUse is already available. The new `vue/lifecycle/prefer-use-event-listener` rule reports `VUE0025` and points users toward `useEventListener()`.

The rule is scoped around Vue-owned listener lifetimes rather than only watcher callbacks: it covers watcher cleanup through `onCleanup` or `onWatcherCleanup`, and broader lifecycle or effect-scope cleanup through `onUnmounted`, `onBeforeUnmount`, and `onScopeDispose`.

Closes #2