### PR TITLE
fix(vue): clarify onUpdated mutation remediation

### DIFF
--- a/docs/rules/metadata.ts
+++ b/docs/rules/metadata.ts
@@ -1473,17 +1473,25 @@ export const ruleDocumentationMetadata = {
   "vue/lifecycle/no-mutation-in-onupdated": {
     description:
       "Flags mutation in onupdated in Vue lifecycle code before it leaks into runtime behavior.",
-    why: "Effects that outlive their component create leaks and stale updates. Register cleanup where Vue or VueUse can dispose it automatically.",
+    why: "onUpdated runs after any DOM update caused by reactive state. Mutating reactive component state there can schedule another update and create an update loop.",
     recommendedReplacement:
-      "Remove mutation in onupdated, or move it to the Vue runtime/API that owns that behavior.",
+      "Do not write to reactive values in onUpdated. Move the state change to the event or state transition that owns it, or use non-reactive local state for bookkeeping that does not drive rendering.",
     examples: [
       {
-        title: "Avoid state mutation in onUpdated",
+        title: "Use non-reactive bookkeeping",
+        language: "vue",
+        invalid:
+          '<script setup lang="ts">\nconst updateCount = ref(0)\nonUpdated(() => {\n  updateCount.value++\n})\n</script>',
+        valid:
+          '<script setup lang="ts">\nlet updateCount = 0\nonUpdated(() => {\n  updateCount++\n})\n</script>',
+      },
+      {
+        title: "Move reactive writes to the owner",
         language: "vue",
         invalid:
           '<script setup lang="ts">\nconst count = ref(0)\nonUpdated(() => {\n  count.value++\n})\n</script>',
         valid:
-          '<script setup lang="ts">\nconst count = ref(0)\nwatchEffect(() => {\n  console.log(count.value)\n})\n</script>',
+          '<script setup lang="ts">\nconst count = ref(0)\n\nfunction increment() {\n  count.value++\n}\n</script>\n\n<template>\n  <button type="button" @click="increment">{{ count }}</button>\n</template>',
       },
     ],
   },

--- a/src/rule-packs/vue/rules/vue/no-mutation-in-on-updated.ts
+++ b/src/rule-packs/vue/rules/vue/no-mutation-in-on-updated.ts
@@ -23,7 +23,7 @@ export const noMutationInOnUpdated = createRule({
           "error",
           "lifecycle",
           "Mutating reactive state in onUpdated can create update loops.",
-          "Move the mutation to the event or watcher that caused the update.",
+          "Move the reactive mutation to the event or state transition that owns it, or keep update bookkeeping in a non-reactive local.",
         );
       },
     };

--- a/tests/rule-packs/vue/run-rule-fixture.test.ts
+++ b/tests/rule-packs/vue/run-rule-fixture.test.ts
@@ -4,6 +4,7 @@ import {
   definePropsWatchGetter,
   noRefAsOperand,
   noBrowserApiInSetup,
+  noMutationInOnUpdated,
   preferComposableRefReturn,
   preferDefineModel,
   preferPropsDestructureDefaults,
@@ -197,6 +198,26 @@ function exportImage() {
   );
 
   expect(result.diagnostics).toHaveLength(0);
+});
+
+test("no mutation in onUpdated suggests owned state transitions or local bookkeeping", async () => {
+  const result = await runRuleFixture({
+    rule: noMutationInOnUpdated,
+    framework: "vue",
+    files: {
+      "app.vue": `<script setup lang="ts">
+const count = ref(0)
+onUpdated(() => {
+  count.value++
+})
+</script>`,
+    },
+  });
+
+  expect(result.diagnostics).toHaveLength(1);
+  expect(result.diagnostics[0]?.suggestion).toBe(
+    "Move the reactive mutation to the event or state transition that owns it, or keep update bookkeeping in a non-reactive local.",
+  );
 });
 
 test("vue browser API rule terminates on recursive client-only call chains", async () => {


### PR DESCRIPTION
## Summary

- Replace the `watchEffect` after-example for `vue/lifecycle/no-mutation-in-onupdated` with non-reactive bookkeeping and owned state-transition examples.
- Update the rule catalog rationale and recommended fix so the docs match Vue's `onUpdated` contract.
- Align the emitted diagnostic suggestion and cover it with a Vue rule fixture test.

## Root Cause

The rule catalog metadata had copied cleanup wording and suggested `watchEffect`, which changes the behavior instead of remediating the `onUpdated` mutation loop risk.

## Validation

- `CI=true pnpm test tests/rule-packs/vue/run-rule-fixture.test.ts docs/app/utils/rule-catalog.test.ts`
- Commit hook ran `vp check --fix`.