### PR TITLE
fix: keep upstream docs out of diagnostic sources

### DIFF
--- a/docs/app/utils/rule-catalog.test.ts
+++ b/docs/app/utils/rule-catalog.test.ts
@@ -4,6 +4,7 @@ import {
   getDiagnosticDocuments,
   getRuleDocuments,
   getRuleReports,
+  diagnosticsCollectionSource,
   rulesCollectionSource,
 } from "../../rules/source.js";
 import { useRuleExplorer } from "../composables/useRuleExplorer.js";
@@ -101,6 +102,24 @@ test("rule source emits markdown with frontmatter and body sections", async () =
   expect(markdown).toContain("## Recommended fix");
   expect(markdown).toContain("## Example");
   expect(markdown).not.toContain("## Metadata");
+});
+
+test("diagnostic source carries upstream docs as reference links", async () => {
+  const diagnostic = getDiagnosticDocuments().find(
+    (item) =>
+      item.ruleId === "nuxt/hydration/no-time-dependent-render-without-nuxttime-or-clientonly",
+  );
+
+  expect(diagnostic?.docsUrl).toBe(
+    "https://nuxt.com/docs/4.x/guide/best-practices/hydration#dynamic-content-based-on-time",
+  );
+
+  const markdown = await diagnosticsCollectionSource.getItem(diagnostic!.key);
+  expect(markdown).toContain("docsUrl:");
+  expect(markdown).toContain("## Useful links");
+  expect(markdown).toContain(
+    "[Upstream docs](https://nuxt.com/docs/4.x/guide/best-practices/hydration#dynamic-content-based-on-time)",
+  );
 });
 
 test("rule source emits complete documentation for every rule", async () => {

--- a/docs/content.config.ts
+++ b/docs/content.config.ts
@@ -40,6 +40,7 @@ export default defineContentConfig({
         code: z.string(),
         why: z.string(),
         fix: z.string(),
+        docsUrl: z.string().optional(),
         ruleId: z.string(),
         pack: z.string(),
         severity: z.enum(["error", "warn", "info"]),

--- a/docs/rules/source.ts
+++ b/docs/rules/source.ts
@@ -40,6 +40,7 @@ export interface DiagnosticDocument {
   description: string;
   why: string;
   fix: string;
+  docsUrl: string;
   ruleId: string;
   pack: string;
   severity: RuleSeverity;
@@ -145,6 +146,7 @@ function collectDiagnosticDocuments(): DiagnosticDocument[] {
         description: rule.description,
         why: rule.why,
         fix: rule.recommendedReplacement,
+        docsUrl: rule.docsUrl,
         ruleId: rule.id,
         pack: rule.pack,
         severity: rule.severity,
@@ -187,6 +189,7 @@ function renderDiagnosticPage(diagnostic: DiagnosticDocument) {
     `code: ${yamlString(diagnostic.code)}`,
     `why: ${yamlString(diagnostic.why)}`,
     `fix: ${yamlString(diagnostic.fix)}`,
+    `docsUrl: ${yamlString(diagnostic.docsUrl || "")}`,
     `ruleId: ${yamlString(diagnostic.ruleId)}`,
     `pack: ${yamlString(diagnostic.pack)}`,
     `severity: ${yamlString(diagnostic.severity)}`,
@@ -208,6 +211,9 @@ function renderDiagnosticPage(diagnostic: DiagnosticDocument) {
     "",
     diagnostic.fix,
     "",
+    ...(diagnostic.docsUrl
+      ? ["## Useful links", "", `- [Upstream docs](${diagnostic.docsUrl})`, ""]
+      : []),
     "## Related rule",
     "",
     `- \`${diagnostic.ruleId}\``,

--- a/src/core/internal/rule-execution.ts
+++ b/src/core/internal/rule-execution.ts
@@ -105,14 +105,6 @@ function createRuleContext(
       file = nextFile;
     },
     report(diagnostic, metadata) {
-      const sources = diagnostic.sources
-        ? [...diagnostic.sources]
-        : rule.meta.docsUrl
-          ? [rule.meta.docsUrl]
-          : undefined;
-      if (rule.meta.docsUrl && sources && !sources.includes(rule.meta.docsUrl))
-        sources.push(rule.meta.docsUrl);
-      if (sources?.length) diagnostic.sources = sources;
       const input = normalizeDiagnostic({
         ...metadata,
         diagnostic,

--- a/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
+++ b/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
@@ -1402,10 +1402,9 @@ test("direct SSR time output still reports", async () => {
   expect(result.diagnostics[0]?.ruleId).toBe(
     "nuxt/hydration/no-time-dependent-render-without-nuxttime-or-clientonly",
   );
-  expect(result.diagnostics[0]?.sources).toContain(
-    "https://nuxt.com/docs/4.x/guide/best-practices/hydration#dynamic-content-based-on-time",
-  );
-  expect(createTextReport(result)).toContain(
+  expect(result.diagnostics[0]?.sources).toBeUndefined();
+  expect(result.diagnostics[0]?.docs).toBe("https://vite-doctor.onmax.me/diagnostics/NUXT0032");
+  expect(createTextReport(result)).not.toContain(
     "sources: https://nuxt.com/docs/4.x/guide/best-practices/hydration#dynamic-content-based-on-time",
   );
 });
@@ -1727,12 +1726,8 @@ test("useState still reports returned Date instances", async () => {
   });
 
   expect(result.diagnostics[0]?.ruleId).toBe("nuxt/state/no-nonserializable-usestate");
-  expect(result.diagnostics[0]?.sources).toContain(
-    "https://nuxt.com/docs/4.x/api/composables/use-state#usage",
-  );
-  expect(createTextReport(result)).toContain(
-    "sources: https://nuxt.com/docs/4.x/api/composables/use-state#usage",
-  );
+  expect(result.diagnostics[0]?.sources).toBeUndefined();
+  expect(createTextReport(result)).not.toContain("sources: https://nuxt.com/docs");
 });
 
 test("Vue lifecycle evidence skips Nuxt content, server, generated, and client-only files", async () => {


### PR DESCRIPTION
Stops copying rule-level upstream docs URLs into Nostics `sources`, keeping that field reserved for source-location strings. Doctor still keeps structured file/range metadata on diagnostics for JSON and SARIF, while generated Diagnostic Reference pages now expose the upstream docs link as reference context.

This aligns the text output with Nostics 0.3.0 source semantics without changing Rule behavior or Diagnostic Codes.