### PR TITLE
feat(nitro): prefer route method suffixes

### DIFF
--- a/src/core/diagnostic-code-map.ts
+++ b/src/core/diagnostic-code-map.ts
@@ -70,6 +70,7 @@ export const allDoctorDiagnosticRegistry = defineDoctorDiagnostics([
   { code: "NITRO0009", ruleId: "nitro/server/no-browser-api" },
   { code: "NITRO0010", ruleId: "nitro/server/no-client-composables" },
   { code: "NITRO0011", ruleId: "nitro/server/prefer-event-fetch" },
+  { code: "NITRO0012", ruleId: "nitro/request/prefer-route-method-suffix" },
   { code: "NUXT0001", ruleId: "docus/appconfig/no-unknown-key" },
   { code: "NUXT0002", ruleId: "docus/layers/no-empty-app-vue-shadow" },
   { code: "NUXT0003", ruleId: "nuxt-better-auth/require-standard-auth-handler-mount" },

--- a/src/rule-packs/nitro/diagnostics.ts
+++ b/src/rule-packs/nitro/diagnostics.ts
@@ -12,6 +12,7 @@ export const nitroDiagnosticRegistry = defineDoctorDiagnostics([
   { code: "NITRO0009", ruleId: "nitro/server/no-browser-api" },
   { code: "NITRO0010", ruleId: "nitro/server/no-client-composables" },
   { code: "NITRO0011", ruleId: "nitro/server/prefer-event-fetch" },
+  { code: "NITRO0012", ruleId: "nitro/request/prefer-route-method-suffix" },
 ]);
 
 export const diagnostics = nitroDiagnosticRegistry.diagnostics;

--- a/src/rule-packs/nitro/rules/index.ts
+++ b/src/rule-packs/nitro/rules/index.ts
@@ -9,6 +9,7 @@ import { preferValidatedBody } from "./prefer-validated-body.js";
 import { preferValidatedQuery } from "./prefer-validated-query.js";
 import { preferValidatedRouterParams } from "./prefer-validated-router-params.js";
 import { preferAssertMethod } from "./prefer-assert-method.js";
+import { preferRouteMethodSuffix } from "./prefer-route-method-suffix.js";
 import { preferGetRequestIp } from "./prefer-get-request-ip.js";
 
 export {
@@ -22,6 +23,7 @@ export {
   preferValidatedQuery,
   preferValidatedRouterParams,
   preferAssertMethod,
+  preferRouteMethodSuffix,
   preferGetRequestIp,
 };
 
@@ -36,6 +38,7 @@ const rules = [
   preferValidatedQuery,
   preferValidatedRouterParams,
   preferAssertMethod,
+  preferRouteMethodSuffix,
   preferGetRequestIp,
 ];
 

--- a/src/rule-packs/nitro/rules/prefer-assert-method.ts
+++ b/src/rule-packs/nitro/rules/prefer-assert-method.ts
@@ -1,5 +1,5 @@
 import { type AnyNode, createRule, report } from "./shared.js";
-import { isSingleMethodCheck } from "./request-helpers.js";
+import { isNitroRouteFile, isSingleMethodCheck } from "./request-helpers.js";
 
 export const preferAssertMethod = createRule({
   meta: {
@@ -17,6 +17,7 @@ export const preferAssertMethod = createRule({
   },
   create(ctx) {
     if (!ctx.helpers.isNuxtServerFile(ctx.file.relativePath)) return;
+    if (isNitroRouteFile(ctx.file.relativePath)) return;
     return {
       ScriptNode(node: AnyNode) {
         const method = isSingleMethodCheck(node, ctx.file.text);

--- a/src/rule-packs/nitro/rules/prefer-route-method-suffix.ts
+++ b/src/rule-packs/nitro/rules/prefer-route-method-suffix.ts
@@ -1,0 +1,117 @@
+import { type AnyNode, createRule, report } from "./shared.js";
+import {
+  isNitroRouteFile,
+  isInIfStatementTest,
+  methodChecks,
+  routeMethodSuffix,
+  routePathWithMethodSuffix,
+  singleMethodCheck,
+  type MethodCheck,
+} from "./request-helpers.js";
+
+const RULE_ID = "nitro/request/prefer-route-method-suffix";
+
+export const preferRouteMethodSuffix = createRule({
+  meta: {
+    id: RULE_ID,
+    title: "Use Nitro route method suffixes",
+    description:
+      "File-routed Nitro handlers should use HTTP method filename suffixes instead of manual request method gates.",
+    why: "Nitro's file router can bind handlers to HTTP methods before user code runs, which keeps unsupported methods out of the handler and makes the route contract visible in the filesystem.",
+    recommendedReplacement:
+      "Use route files such as server/api/user.get.ts or server/api/user.post.ts instead of checking request.method inside the handler.",
+    examples: [
+      {
+        title: "Move method gates into the route filename",
+        language: "ts",
+        invalid:
+          "export default defineEventHandler((event) => {\n  if (getMethod(event) !== 'POST') throw createError({ statusCode: 405 })\n  return createUser(event)\n})",
+        valid:
+          "// server/api/user.post.ts\nexport default defineEventHandler((event) => {\n  return createUser(event)\n})",
+      },
+    ],
+    category: "request",
+    severity: "warn",
+    fixable: "suggestion",
+    docsUrl: "https://nitro.build/docs/routing#specific-request-method",
+    requires: { script: true, nitro: true },
+  },
+  create(ctx) {
+    if (!isNitroRouteFile(ctx.file.relativePath)) return;
+
+    return {
+      ScriptNode(node: AnyNode) {
+        if (node.type === "IfStatement") {
+          const checks = methodChecks(node.test, ctx.file.text, node);
+          if (!checks.length) return;
+          reportMethodCheck(node.test ?? node, checks, wholeHandlerAllowed(node, checks));
+          return;
+        }
+
+        if (node.type !== "BinaryExpression" || isInIfStatementTest(node)) return;
+        const check = singleMethodCheck(node, ctx.file.text, node);
+        if (!check) return;
+        reportMethodCheck(node, [check], false);
+      },
+    };
+
+    function reportMethodCheck(node: AnyNode, checks: MethodCheck[], wholeHandler: boolean) {
+      const methods = methodsFromChecks(checks);
+      const suffix = routeMethodSuffix(ctx.file.relativePath);
+      const suggestion =
+        suffix && isRedundantSuffix(suffix, methods)
+          ? `Remove the manual method guard; .${suffix.toLowerCase()}.ts already constrains this route.`
+          : methodSuffixSuggestion(ctx.file.relativePath, methods, wholeHandler);
+      report(
+        ctx,
+        node,
+        RULE_ID,
+        "warn",
+        "request",
+        `This file-routed Nitro handler checks ${formatMethods(methods)} manually.`,
+        suggestion,
+      );
+    }
+  },
+});
+
+function formatMethods(methods: string[]) {
+  return methods.length === 1 ? methods[0]! : methods.join("/");
+}
+
+function isRedundantSuffix(suffix: string | null, methods: string[]) {
+  return methods.length === 1 && methods[0] === suffix;
+}
+
+function methodSuffixSuggestion(relativePath: string, methods: string[], wholeHandler: boolean) {
+  const paths = methods.map((method) =>
+    routePathWithMethodSuffix(relativePath, method.toLowerCase()),
+  );
+  if (wholeHandler && paths.length === 1)
+    return `Move this handler to ${paths[0]} and remove the manual method guard.`;
+  if (wholeHandler)
+    return `Split this handler into ${formatList(paths)} and remove the manual method guard.`;
+  if (paths.length === 1)
+    return `Move the ${methods[0]}-specific branch to ${paths[0]} and keep other method behavior in method-suffixed route files.`;
+  return `Move the method-specific branches to ${formatList(paths)} and keep other method behavior in method-suffixed route files.`;
+}
+
+function formatList(items: string[]) {
+  if (items.length <= 1) return items[0] ?? "";
+  return `${items.slice(0, -1).join(", ")} and ${items.at(-1)}`;
+}
+
+function methodsFromChecks(checks: MethodCheck[]) {
+  return [...new Set(checks.map((check) => check.method))];
+}
+
+function wholeHandlerAllowed(node: AnyNode, checks: MethodCheck[]) {
+  return checks.every((check) => check.isNegative) && branchExits(node.consequent);
+}
+
+function branchExits(node: AnyNode) {
+  if (!node) return false;
+  if (node.type === "ReturnStatement" || node.type === "ThrowStatement") return true;
+  if (node.type !== "BlockStatement") return false;
+  return branchExits(node.body?.at(-1));
+}

--- a/src/rule-packs/nitro/rules/request-helpers.ts
+++ b/src/rule-packs/nitro/rules/request-helpers.ts
@@ -26,6 +26,12 @@ export interface ValidatedInputRuleOptions {
   docsUrl?: string;
 }
 
+export interface MethodCheck {
+  method: string;
+  operator: "===" | "==" | "!==" | "!=";
+  isNegative: boolean;
+}
+
 export function createValidatedInputRule(opts: ValidatedInputRuleOptions) {
   return createRule({
     meta: {
@@ -100,18 +106,80 @@ export function isRequestSensitiveUse(ctx: RuleContext, node: AnyNode) {
   );
 }
 
-export function isSingleMethodCheck(node: AnyNode, source: string) {
+export function singleMethodCheck(
+  node: AnyNode,
+  source: string,
+  anchor: AnyNode = node,
+): MethodCheck | null {
   if (node.type !== "BinaryExpression") return null;
   const operator = node.operator;
   if (operator !== "===" && operator !== "==" && operator !== "!==" && operator !== "!=")
     return null;
-  const leftMethod = methodExpressionName(node.left, source);
-  const rightMethod = methodExpressionName(node.right, source);
+  const leftMethod = methodExpressionName(node.left, source, anchor);
+  const rightMethod = methodExpressionName(node.right, source, anchor);
   const method = staticString(node.left, source) ?? staticString(node.right, source);
   if (!method || (!leftMethod && !rightMethod)) return null;
   const normalized = method.toUpperCase();
-  if (!/^(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)$/.test(normalized)) return null;
-  return normalized;
+  if (!isHttpMethod(normalized)) return null;
+  return { method: normalized, operator, isNegative: operator === "!==" || operator === "!=" };
+}
+
+export function isSingleMethodCheck(node: AnyNode, source: string, anchor: AnyNode = node) {
+  return singleMethodCheck(node, source, anchor)?.method ?? null;
+}
+
+export function methodChecks(node: AnyNode, source: string, anchor: AnyNode = node) {
+  const checks = new Map<string, MethodCheck>();
+  walkScriptLocal(node, (child) => {
+    const check = singleMethodCheck(child, source, anchor);
+    if (check) checks.set(`${check.method}:${check.operator}`, check);
+  });
+  return [...checks.values()];
+}
+
+export function methodCheckMethods(node: AnyNode, source: string, anchor: AnyNode = node) {
+  return [...new Set(methodChecks(node, source, anchor).map((check) => check.method))];
+}
+
+export function isInIfStatementTest(node: AnyNode) {
+  let current = node;
+  while (current) {
+    const parent = current.__doctorParent;
+    if (!parent) return false;
+    if (parent.type === "IfStatement" && parent.test === current) return true;
+    current = parent;
+  }
+  return false;
+}
+
+export function isNitroRouteFile(relativePath: string) {
+  const path = normalizePath(relativePath);
+  return /^(?:(?:app\/)?server\/)?(?:api|routes)\/.+\.[cm]?[jt]s$/.test(path);
+}
+
+export function routeMethodSuffix(relativePath: string) {
+  const path = normalizePath(relativePath);
+  const match = path.match(/\.([a-z]+)(?:\.(?:dev|prod|prerender))?\.[cm]?[jt]s$/);
+  const method = match?.[1]?.toUpperCase();
+  return method && isHttpMethod(method) ? method : null;
+}
+
+export function routePathWithMethodSuffix(relativePath: string, suffix: string) {
+  const path = normalizePath(relativePath);
+  const existingMethod = routeMethodSuffix(path);
+  if (existingMethod) {
+    return path.replace(
+      new RegExp(
+        `\\.${existingMethod.toLowerCase()}(\\.(?:dev|prod|prerender))?(\\.[cm]?[jt]s)$`,
+        "i",
+      ),
+      `.${suffix}$1$2`,
+    );
+  }
+  return path.replace(
+    /(\.(?:dev|prod|prerender))?(\.[cm]?[jt]s)$/,
+    (_match, env = "", extension) => `.${suffix}${env}${extension}`,
+  );
 }
 
 function rawInputVariable(node: AnyNode, rawUtilities: string[]) {
@@ -159,10 +227,24 @@ function isSchemaMethodValidatorCall(node: AnyNode, variable: string, source: st
   );
 }
 
-function methodExpressionName(node: AnyNode, source: string) {
+function methodExpressionName(
+  node: AnyNode,
+  source: string,
+  anchor?: AnyNode,
+  seen: Set<string> = new Set(),
+) {
   if (node.type === "CallExpression" && calleeName(node) === "getMethod") return "getMethod";
   const text = sourceForNode(node, source);
-  return /\bevent\.method\b|\bevent\.node\.req\.method\b/.test(text) ? text : null;
+  if (/\bevent\.(?:method|req\.method|node\.req\.method)\b/.test(text)) return text;
+  if (anchor && isMemberMethodRead(node, source, anchor, seen)) return text;
+  if (
+    node.type === "Identifier" &&
+    anchor &&
+    !seen.has(node.name) &&
+    isMethodAlias(anchor, node.name, source, seen)
+  )
+    return node.name;
+  return null;
 }
 
 function staticString(node: AnyNode, source: string) {
@@ -182,4 +264,83 @@ function calleeName(node: AnyNode) {
   return node?.callee?.type === "Identifier"
     ? node.callee.name
     : (node?.callee?.property?.name ?? null);
+}
+
+function isMemberMethodRead(node: AnyNode, source: string, anchor: AnyNode, seen: Set<string>) {
+  if (!node || (node.type !== "MemberExpression" && node.type !== "StaticMemberExpression"))
+    return false;
+  if (node.computed) return false;
+  if (node.property?.name !== "method") return false;
+  const object = node.object;
+  const objectText = sourceForNode(object, source);
+  if (/^event\.(?:req|node\.req)$/.test(objectText)) return true;
+  if (object?.type === "Identifier" && anchor)
+    return isRequestAlias(anchor, object.name, source, seen);
+  return false;
+}
+
+function isRequestAlias(anchor: AnyNode, name: string, source: string, seen: Set<string>) {
+  const declaration = findVariableDeclarationBefore(anchor, name);
+  if (!declaration) return false;
+  const init = declaration.init;
+  if (!init) return false;
+  const text = sourceForNode(init, source);
+  if (/^event\.(?:req|node\.req)$/.test(text)) return true;
+  if (init?.type === "Identifier" && !seen.has(init.name)) {
+    seen.add(init.name);
+    return isRequestAlias(anchor, init.name, source, seen);
+  }
+  return false;
+}
+
+function isMethodAlias(anchor: AnyNode, name: string, source: string, seen: Set<string>) {
+  const declaration = findVariableDeclarationBefore(anchor, name);
+  if (!declaration?.init) return false;
+  seen.add(name);
+  return Boolean(methodExpressionName(declaration.init, source, anchor, seen));
+}
+
+function findVariableDeclarationBefore(anchor: AnyNode, name: string) {
+  let child = anchor;
+  let scope = child.__doctorParent;
+  while (scope) {
+    if (scope.type === "BlockStatement" || scope.type === "Program") {
+      const declaration = findDeclarationInScopeBefore(scope, child, name);
+      if (declaration) return declaration;
+    }
+    child = scope;
+    scope = scope.__doctorParent;
+  }
+  return null;
+}
+
+function findDeclarationInScopeBefore(scope: AnyNode, child: AnyNode, name: string) {
+  let match: any = null;
+  for (const statement of scope.body ?? []) {
+    if (statement === child) break;
+    const statementStart = statement.start ?? statement.range?.[0] ?? 0;
+    const childStart = child.start ?? child.range?.[0] ?? 0;
+    if (statementStart >= childStart) break;
+    const declaration = variableDeclarationFromStatement(statement, name);
+    if (declaration) match = declaration;
+  }
+  return match;
+}
+
+function variableDeclarationFromStatement(statement: AnyNode, name: string) {
+  if (statement.type !== "VariableDeclaration") return null;
+  return (
+    statement.declarations?.find(
+      (declaration: AnyNode) =>
+        declaration.id?.type === "Identifier" && declaration.id.name === name,
+    ) ?? null
+  );
+}
+
+function isHttpMethod(method: string) {
+  return /^(GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|CONNECT|TRACE)$/.test(method);
+}
+
+function normalizePath(path: string) {
+  return path.replace(/\\/g, "/");
 }

--- a/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
+++ b/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
@@ -57,6 +57,7 @@ import {
   noClientComposablesInServer,
   preferEventFetch,
   preferAssertMethod,
+  preferRouteMethodSuffix,
   preferGetRequestIp,
   preferValidatedBody,
   preferValidatedQuery,
@@ -275,6 +276,15 @@ const cases = [
     id: "nitro/server/no-browser-api",
     file: "server/api/user.ts",
     source: `export default defineEventHandler(() => window.location.href)`,
+  },
+  {
+    rule: preferRouteMethodSuffix,
+    id: "nitro/request/prefer-route-method-suffix",
+    file: "server/api/user.ts",
+    source: `export default defineEventHandler((event) => {
+  if (getMethod(event) !== 'POST') throw createError({ statusCode: 405 })
+  return {}
+})`,
   },
   {
     rule: preferCreateUseFetch,
@@ -1051,6 +1061,7 @@ test("Nitro pack is exported and consumed by Nuxt rule packs", () => {
       "nitro/request/prefer-validated-query",
       "nitro/request/prefer-validated-router-params",
       "nitro/request/prefer-assert-method",
+      "nitro/request/prefer-route-method-suffix",
       "nitro/request/prefer-get-request-ip",
     ]),
   );
@@ -1134,7 +1145,124 @@ test("Nitro validation rules ignore validated utilities and unrelated validation
   expect(unrelated.diagnostics).toHaveLength(0);
 });
 
-test("Nitro request rules prefer assertMethod for single-method checks", async () => {
+test("Nitro request rules prefer route method suffixes for file-routed method gates", async () => {
+  const result = await runRuleFixture({
+    rule: preferRouteMethodSuffix,
+    framework: "nuxt",
+    files: {
+      "server/routes/tasks/[...asset].ts": `export default defineEventHandler((event) => {
+  const request = event.req
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return Response.json({ error: 'Method not allowed.' }, { status: 405 })
+  }
+  return {}
+})`,
+    },
+  });
+
+  expect(result.diagnostics[0]?.ruleId).toBe("nitro/request/prefer-route-method-suffix");
+  expect(result.diagnostics[0]?.suggestion).toContain("server/routes/tasks/[...asset].get.ts");
+  expect(result.diagnostics[0]?.suggestion).toContain("server/routes/tasks/[...asset].head.ts");
+});
+
+test("Nitro route method suffix rule reports redundant guards in suffixed route files", async () => {
+  const result = await runRuleFixture({
+    rule: preferRouteMethodSuffix,
+    framework: "nuxt",
+    files: {
+      "server/api/user.post.ts": `export default defineEventHandler((event) => {
+  if (event.req.method !== 'POST') throw createError({ statusCode: 405 })
+  return {}
+})`,
+    },
+  });
+
+  expect(result.diagnostics[0]?.suggestion).toContain(".post.ts already constrains this route");
+});
+
+test("Nitro route method suffix rule does not treat mismatched suffixed route guards as redundant", async () => {
+  const result = await runRuleFixture({
+    rule: preferRouteMethodSuffix,
+    framework: "nuxt",
+    files: {
+      "server/api/user.get.ts": `export default defineEventHandler((event) => {
+  if (event.req.method !== 'POST') throw createError({ statusCode: 405 })
+  return {}
+})`,
+    },
+  });
+
+  expect(result.diagnostics[0]?.suggestion).toContain("server/api/user.post.ts");
+  expect(result.diagnostics[0]?.suggestion).not.toContain("already constrains this route");
+});
+
+test("Nitro route method suffix rule does not suggest moving whole handlers for positive dispatch", async () => {
+  const result = await runRuleFixture({
+    rule: preferRouteMethodSuffix,
+    framework: "nuxt",
+    files: {
+      "server/api/users.ts": `export default defineEventHandler((event) => {
+  if (event.req.method === 'POST') return createUser(event)
+  return listUsers(event)
+})`,
+    },
+  });
+
+  expect(result.diagnostics[0]?.suggestion).toContain("POST-specific branch");
+  expect(result.diagnostics[0]?.suggestion).not.toContain("Move this handler");
+});
+
+test("Nitro route method suffix rule reports non-if method gates in file-routed handlers", async () => {
+  const result = await runRuleFixture({
+    rule: preferRouteMethodSuffix,
+    framework: "nuxt",
+    files: {
+      "server/api/user.ts": `export default defineEventHandler((event) => {
+  return event.req.method !== 'POST' ? Response.json({}, { status: 405 }) : updateUser(event)
+})`,
+    },
+  });
+
+  expect(result.diagnostics[0]?.ruleId).toBe("nitro/request/prefer-route-method-suffix");
+  expect(result.diagnostics[0]?.suggestion).toContain("POST-specific branch");
+});
+
+test("Nitro route method suffix rule ignores request aliases from unrelated nested scopes", async () => {
+  const result = await runRuleFixture({
+    rule: preferRouteMethodSuffix,
+    framework: "nuxt",
+    files: {
+      "server/api/user.ts": `export default defineEventHandler((event) => {
+  function readNestedRequest() {
+    const request = event.req
+    return request.method
+  }
+  const request = { method: 'POST' }
+  if (request.method !== 'POST') return readNestedRequest()
+  return {}
+})`,
+    },
+  });
+
+  expect(result.diagnostics).toHaveLength(0);
+});
+
+test("Nitro request rules prefer assertMethod for non-file-routed single-method checks", async () => {
+  const result = await runRuleFixture({
+    rule: preferAssertMethod,
+    framework: "nuxt",
+    files: {
+      "server/middleware/api-auth.ts": `export default defineEventHandler((event) => {
+  if (getMethod(event) !== 'POST') throw createError({ statusCode: 405 })
+  return {}
+})`,
+    },
+  });
+
+  expect(result.diagnostics[0]?.ruleId).toBe("nitro/request/prefer-assert-method");
+});
+
+test("Nitro assertMethod rule ignores file-routed method gates", async () => {
   const result = await runRuleFixture({
     rule: preferAssertMethod,
     framework: "nuxt",
@@ -1146,7 +1274,7 @@ test("Nitro request rules prefer assertMethod for single-method checks", async (
     },
   });
 
-  expect(result.diagnostics[0]?.ruleId).toBe("nitro/request/prefer-assert-method");
+  expect(result.diagnostics).toHaveLength(0);
 });
 
 test("Nitro request IP rule reports only request-sensitive raw header reads", async () => {


### PR DESCRIPTION
Adds a Nitro request rule that reports manual HTTP method gates in file-routed handlers and points users to Nitro's method suffix route files. It recognizes getMethod/event.req.method patterns, avoids double-reporting with assertMethod on file-routed handlers, and registers NITRO0012 so the rule appears in Doctor diagnostics and docs.

The rule gives split-file guidance for multi-method guards such as GET/HEAD and only treats suffixed routes as redundant when the checked method matches the suffix.