### PR TITLE
fix(nuxt): detect resolved explicit auto-imports

### DIFF
--- a/.changeset/quiet-lions-import.md
+++ b/.changeset/quiet-lions-import.md
@@ -1,0 +1,5 @@
+---
+"vite-doctor": patch
+---
+
+Respect Nuxt's resolved auto-import configuration when reporting redundant explicit imports.

--- a/docs/rules/metadata.ts
+++ b/docs/rules/metadata.ts
@@ -748,16 +748,16 @@ export const ruleDocumentationMetadata = {
   },
   "nuxt/imports/no-explicit-auto-import": {
     description:
-      "Flags explicit auto import in Nuxt imports code before it leaks into runtime behavior.",
-    why: "Auto-imports are global within a project. Explicit names and imports prevent local code from shadowing framework composables.",
+      "Flags value imports that duplicate the auto-imports enabled for the current Nuxt project and file.",
+    why: "Nuxt's resolved import registry already accounts for framework APIs, modules, aliases, and scanned app directories. Reusing that registry keeps imports consistent with the project's active configuration.",
     recommendedReplacement:
-      "Remove explicit auto import, or move it to the Nuxt runtime/API that owns that behavior.",
+      "Remove the redundant value import. Keep explicit imports when Nuxt auto-importing is disabled or the file is excluded from transformation.",
     examples: [
       {
-        title: "Use Nuxt auto-imports directly",
+        title: "Use configured app utility auto-imports directly",
         language: "ts",
-        invalid: "import { useRoute } from '#imports'\n\nconst route = useRoute()",
-        valid: "const route = useRoute()",
+        invalid: "import { formatPrice } from '~/utils/format'\n\nconst label = formatPrice(total)",
+        valid: "const label = formatPrice(total)",
       },
     ],
   },

--- a/src/core/internal/nuxt-inventory.ts
+++ b/src/core/internal/nuxt-inventory.ts
@@ -6,6 +6,10 @@ export interface NuxtProjectInventory {
   pluginFiles: string[];
   keyedComposables: string[];
   aliases: Record<string, string>;
+  autoImportTransform?: {
+    include: Array<{ source: string; flags: string }>;
+    exclude: Array<{ source: string; flags: string }>;
+  };
   appScanRoots: string[];
   sharedScanRoots: string[];
   hasManifest: boolean;
@@ -34,6 +38,7 @@ export function createNuxtProjectInventory(
     pluginFiles: (manifest?.pluginFiles ?? []).map((file) => resolve(root, file)),
     keyedComposables: (manifest?.keyedComposables ?? []).map(String),
     aliases: manifest?.aliases ?? {},
+    autoImportTransform: manifest?.autoImportTransform,
     appScanRoots: (manifest?.appScanRoots ?? [manifest?.appDir ?? "app"]).map((dir) =>
       resolve(root, dir),
     ),

--- a/src/core/internal/project.ts
+++ b/src/core/internal/project.ts
@@ -12,6 +12,7 @@ import { createNuxtProjectInventory, normalizeNuxtModuleSources } from "./nuxt-i
 import type { RuntimeTarget } from "../primitives.js";
 import {
   applyRuntimeTarget,
+  isNuxtManifestCurrent,
   resolveNuxtCompatibility,
   resolveRuntimeGraph,
 } from "./runtime-graph.js";
@@ -128,6 +129,9 @@ async function normalizeNuxtProject(
     appRoots: manifest?.layers?.length
       ? manifest.layers.map((layer) => resolve(root, layer.root)).sort()
       : await detectNuxtAppRoots(root),
+    autoImportEnabled: manifest ? manifest.autoImportEnabled === true : true,
+    autoImportsAuthoritative:
+      manifest?.autoImportEnabled !== undefined && isNuxtManifestCurrent(root, manifest),
     autoImports: new Map(
       (manifest?.autoImports ?? coreAutoImports()).map((entry: any) => [
         entry.as ?? entry.name,

--- a/src/core/internal/runtime-graph.ts
+++ b/src/core/internal/runtime-graph.ts
@@ -71,16 +71,10 @@ export function resolveNuxtCompatibility(
   if (!graph.packages.nuxt) return undefined;
   const config = readNuxtConfig(root);
   const manifestGeneratedAt = manifest?.generatedAt ? Date.parse(manifest.generatedAt) : Number.NaN;
-  const configModifiedAt = config ? configModifiedTime(config.file) : undefined;
-  const manifestMatchesConfig =
-    configModifiedAt === undefined ||
-    (Number.isFinite(manifest?.nuxtConfigMtimeMs)
-      ? manifest?.nuxtConfigMtimeMs === configModifiedAt
-      : manifestGeneratedAt >= configModifiedAt);
   if (
     Number.isFinite(manifestGeneratedAt) &&
     isSupportedNuxtCompatibility(manifest?.compatibilityVersion) &&
-    manifestMatchesConfig
+    isNuxtManifestCurrent(root, manifest)
   ) {
     return {
       state: "resolved",
@@ -122,6 +116,16 @@ export function resolveNuxtCompatibility(
     version: Number(nuxt.version.split(".")[0]) >= 5 ? 5 : 4,
     provenance: "default",
   };
+}
+
+export function isNuxtManifestCurrent(root: string, manifest: NuxtDoctorManifest | null) {
+  if (!manifest?.generatedAt || !Number.isFinite(Date.parse(manifest.generatedAt))) return false;
+  const config = readNuxtConfig(root);
+  const configModifiedAt = config ? configModifiedTime(config.file) : undefined;
+  if (configModifiedAt === undefined) return true;
+  return Number.isFinite(manifest.nuxtConfigMtimeMs)
+    ? manifest.nuxtConfigMtimeMs === configModifiedAt
+    : Date.parse(manifest.generatedAt) >= configModifiedAt;
 }
 
 function isSupportedNuxtCompatibility(value: unknown): value is 4 | 5 {

--- a/src/core/primitives.ts
+++ b/src/core/primitives.ts
@@ -196,12 +196,15 @@ export interface AutoImportEntry {
   from: string;
   kind: "nuxt" | "vue" | "module" | "app" | "layer";
   sourceLayer?: string;
+  type?: boolean;
 }
 
 export interface NuxtProjectInfo {
   version: string;
   appDir: string;
   appRoots: string[];
+  autoImportEnabled: boolean;
+  autoImportsAuthoritative: boolean;
   autoImports: Map<string, AutoImportEntry>;
   components: Map<
     string,
@@ -225,6 +228,10 @@ export interface NuxtProjectInfo {
     pluginFiles: string[];
     keyedComposables: string[];
     aliases: Record<string, string>;
+    autoImportTransform?: {
+      include: Array<{ source: string; flags: string }>;
+      exclude: Array<{ source: string; flags: string }>;
+    };
     appScanRoots: string[];
     sharedScanRoots: string[];
     hasManifest: boolean;
@@ -263,6 +270,11 @@ export interface NuxtDoctorManifest {
   srcDir: string;
   appDir: string;
   buildDir: string;
+  autoImportEnabled?: boolean;
+  autoImportTransform?: {
+    include: Array<{ source: string; flags: string }>;
+    exclude: Array<{ source: string; flags: string }>;
+  };
   autoImports: unknown[];
   components: unknown[];
   layers: Array<{ root: string; name?: string; priority: number }>;

--- a/src/rule-packs/nuxt/module.ts
+++ b/src/rule-packs/nuxt/module.ts
@@ -20,6 +20,19 @@ type EvidenceBuildManifest = {
   chunks: Array<{ file?: string; src?: string; isEntry?: boolean; isDynamicEntry?: boolean }>;
 };
 
+type NuxtAutoImportContext = {
+  getImports?: () => Promise<unknown[]> | unknown[];
+};
+
+type NuxtDoctorEvidence = {
+  pages?: Array<{ path?: string; file?: string; name?: string }>;
+  prerenderRoutes?: Set<string>;
+  buildManifest?: EvidenceBuildManifest;
+  componentDirs?: unknown[];
+  importDirs?: unknown[];
+  autoImportContext?: NuxtAutoImportContext;
+};
+
 export default async function nuxtDoctorModule(options: NuxtDoctorModuleOptions = {}, nuxt: any) {
   nuxt.options ??= {};
   nuxt.options.doctor ??= {};
@@ -33,7 +46,12 @@ export default async function nuxtDoctorModule(options: NuxtDoctorModuleOptions 
     buildManifest: undefined as EvidenceBuildManifest | undefined,
     componentDirs: [] as unknown[],
     importDirs: [] as unknown[],
+    autoImportContext: undefined as NuxtAutoImportContext | undefined,
   };
+
+  nuxt.hook?.("imports:context", (context: NuxtAutoImportContext) => {
+    evidence.autoImportContext = context;
+  });
 
   nuxt.hook?.("pages:resolved", (pages: any[]) => {
     evidence.pages = flattenPages(pages).map((page: any) => ({
@@ -94,17 +112,12 @@ export async function collectNuxtDoctorExtensions(nuxt: any): Promise<DoctorExte
 
 export async function writeManifest(
   nuxt: any,
-  evidence?: {
-    pages?: Array<{ path?: string; file?: string; name?: string }>;
-    prerenderRoutes?: Set<string>;
-    buildManifest?: EvidenceBuildManifest;
-    componentDirs?: unknown[];
-    importDirs?: unknown[];
-  },
+  evidence?: NuxtDoctorEvidence,
 ): Promise<NuxtDoctorManifest> {
   const rootDir = resolve(nuxt.options.rootDir ?? process.cwd());
   const buildDir = resolve(rootDir, nuxt.options.buildDir ?? ".nuxt");
-  const appDir = resolve(rootDir, nuxt.options.appDir ?? "app");
+  const srcDir = resolve(rootDir, nuxt.options.srcDir ?? ".");
+  const appDir = srcDir;
   const moduleSources: NuxtModuleSource[] = [];
   await nuxt.callHook?.("doctor:extendSources", moduleSources);
   const modules = toArray(nuxt.options.modules).map((entry: any) => ({
@@ -113,16 +126,21 @@ export async function writeManifest(
     version: entry?.meta?.version,
     doctorPlugin: entry?.doctor?.plugin,
   }));
+  const resolvedAutoImports = evidence?.autoImportContext?.getImports
+    ? await evidence.autoImportContext.getImports()
+    : toArray(nuxt.options.imports?.imports);
   const manifest = {
     nuxtConfigMtimeMs: nuxtConfigModifiedAt(rootDir),
     nuxtVersion: nuxt._version ?? nuxt.version ?? "4",
     vueVersion: nuxt.options.vue?.version ?? "3.5",
     compatibilityVersion: nuxt.options.future?.compatibilityVersion,
     rootDir,
-    srcDir: resolve(rootDir, nuxt.options.srcDir ?? "."),
+    srcDir,
     appDir,
     buildDir,
-    autoImports: toArray(nuxt.options.imports?.imports ?? nuxt._imports?.imports),
+    autoImportEnabled: nuxt.options.imports?.autoImport !== false,
+    autoImportTransform: serializeImportTransform(nuxt.options.imports?.transform),
+    autoImports: normalizeAutoImports(resolvedAutoImports),
     components: toArray(nuxt.options.components ?? nuxt._components),
     layers: toArray(nuxt.options._layers ?? [{ cwd: rootDir }]).map(
       (layer: any, index: number) => ({
@@ -211,6 +229,28 @@ function normalizeDirs(rootDir: string, dirs: unknown[]): string[] {
     .map((dir: any) => (typeof dir === "string" ? dir : dir?.path))
     .filter(Boolean)
     .map((dir: string) => resolve(rootDir, dir));
+}
+
+function normalizeAutoImports(imports: unknown[]) {
+  return imports
+    .map((entry: any) => ({
+      name: entry?.name,
+      as: entry?.as,
+      from: entry?.from,
+      type: entry?.type === true || undefined,
+    }))
+    .filter((entry) => entry.name && entry.from);
+}
+
+function serializeImportTransform(transform: any) {
+  const serialize = (patterns: unknown[]) =>
+    patterns
+      .filter((pattern): pattern is RegExp => pattern instanceof RegExp)
+      .map(({ source, flags }) => ({ source, flags }));
+  return {
+    include: serialize(toArray(transform?.include)),
+    exclude: serialize(toArray(transform?.exclude)),
+  };
 }
 
 function normalizePluginFiles(rootDir: string, plugins: unknown[]): string[] {

--- a/src/rule-packs/nuxt/rules/nuxt/no-explicit-auto-import.ts
+++ b/src/rule-packs/nuxt/rules/nuxt/no-explicit-auto-import.ts
@@ -1,10 +1,18 @@
-import { AnyNode, NUXT_AUTO_IMPORTS, createRule, includeTrailingNewline } from "./shared.js";
+import { dirname, isAbsolute, resolve } from "pathe";
+import type { RuleContext } from "../../../../core/index.js";
+import {
+  AnyNode,
+  createRule,
+  includeTrailingNewline,
+  isNuxtRuntimeFile,
+  toPosixPath,
+} from "./shared.js";
 import { diagnostics } from "../../diagnostics.js";
 
 export const noExplicitAutoImport = createRule({
   meta: {
     id: "nuxt/imports/no-explicit-auto-import",
-    title: "Avoid explicit imports of Nuxt auto-imports",
+    title: "Use configured Nuxt auto-imports directly",
     category: "imports",
     severity: "info",
     fixable: "safe",
@@ -14,21 +22,42 @@ export const noExplicitAutoImport = createRule({
   create(ctx) {
     return {
       ImportDeclaration(node: AnyNode) {
-        if (node.source?.value !== "#imports") return;
+        if (
+          !isNuxtRuntimeFile(ctx) ||
+          !ctx.project.nuxt?.autoImportEnabled ||
+          !ctx.project.nuxt.autoImportsAuthoritative
+        )
+          return;
+        if (!isAutoImportTransformEnabled(ctx.file.path, ctx.project.nuxt.manifest)) return;
+        const source = String(node.source?.value ?? "");
         const specifiers =
-          node.specifiers?.filter((specifier: AnyNode) =>
-            NUXT_AUTO_IMPORTS.has(specifier.imported?.name),
-          ) ?? [];
+          node.specifiers?.filter((specifier: AnyNode) => {
+            if (specifier.type !== "ImportSpecifier") return false;
+            if (node.importKind === "type" || specifier.importKind === "type") return false;
+            const imported = String(specifier.imported?.name ?? specifier.imported?.value ?? "");
+            const local = String(specifier.local?.name ?? imported);
+            const entry = ctx.project.nuxt?.autoImports.get(
+              source === "#imports" ? imported : local,
+            );
+            if (!entry || entry.type) return false;
+            if (source === "#imports")
+              return local === imported && imported === (entry.as ?? entry.name);
+            return (
+              imported === entry.name &&
+              local === (entry.as ?? entry.name) &&
+              sameImportSource(ctx, source, entry.from)
+            );
+          }) ?? [];
         if (!specifiers.length) return;
         const all = specifiers.length === node.specifiers.length;
         ctx.report(
           diagnostics.NUXT0036({
-            why: "This imports symbols that Nuxt already auto-imports. Keeping code auto-imported is the Nuxt default; configure this rule off if your team prefers explicit #imports.",
-            fix: "Remove the explicit #imports import when all specifiers are auto-imported.",
+            why: "This imports symbols that Nuxt is configured to auto-import in this file.",
+            fix: "Remove the explicit import when all specifiers are auto-imported.",
           }),
           {
             ruleId: "nuxt/imports/no-explicit-auto-import",
-            severity: "info",
+            severity: ctx.severity,
             category: "imports",
             file: ctx.file.path,
             range: ctx.range(node),
@@ -52,3 +81,51 @@ export const noExplicitAutoImport = createRule({
     };
   },
 });
+
+function sameImportSource(ctx: RuleContext, source: string, autoImportSource: string) {
+  const explicit = resolveImportSource(ctx, source);
+  const automatic = resolveImportSource(ctx, autoImportSource);
+  return explicit && automatic ? explicit === automatic : source === autoImportSource;
+}
+
+function resolveImportSource(ctx: RuleContext, source: string): string | null {
+  if (isAbsolute(source)) return canonicalPath(source);
+  if (source.startsWith("~~/") || source.startsWith("@@/"))
+    return canonicalPath(resolve(ctx.project.root, source.slice(3)));
+  if (source.startsWith("~/") || source.startsWith("@/"))
+    return canonicalPath(resolve(ctx.project.nuxt!.appDir, source.slice(2)));
+  if (source.startsWith(".")) return canonicalPath(resolve(dirname(ctx.file.path), source));
+
+  const aliases = Object.entries(ctx.project.nuxt!.manifest?.aliases ?? {}).sort(
+    ([left], [right]) => right.length - left.length,
+  );
+  for (const [alias, target] of aliases) {
+    if (source !== alias && !source.startsWith(`${alias}/`)) continue;
+    return canonicalPath(resolve(String(target), source.slice(alias.length).replace(/^\//, "")));
+  }
+  return null;
+}
+
+function canonicalPath(path: string) {
+  return toPosixPath(resolve(path))
+    .replace(/\.(?:[cm]?[jt]sx?|vue)$/, "")
+    .replace(/\/index$/, "");
+}
+
+function isAutoImportTransformEnabled(
+  file: string,
+  manifest: NonNullable<RuleContext["project"]["nuxt"]>["manifest"],
+) {
+  const transform = manifest?.autoImportTransform;
+  if (!transform) return true;
+  if (transform.include.some((pattern) => matchesPattern(file, pattern))) return true;
+  return !transform.exclude.some((pattern) => matchesPattern(file, pattern));
+}
+
+function matchesPattern(file: string, pattern: { source: string; flags: string }) {
+  try {
+    return new RegExp(pattern.source, pattern.flags).test(file);
+  } catch {
+    return false;
+  }
+}

--- a/src/rule-packs/nuxt/rules/nuxt/no-explicit-auto-import.ts
+++ b/src/rule-packs/nuxt/rules/nuxt/no-explicit-auto-import.ts
@@ -14,7 +14,7 @@ export const noExplicitAutoImport = createRule({
     id: "nuxt/imports/no-explicit-auto-import",
     title: "Use configured Nuxt auto-imports directly",
     category: "imports",
-    severity: "info",
+    severity: "warn",
     fixable: "safe",
     docsUrl: "https://nuxt.com/docs/4.x/guide/concepts/auto-imports#explicit-imports",
     requires: { script: true, nuxt: true },

--- a/tests/core/runtime-graph.test.ts
+++ b/tests/core/runtime-graph.test.ts
@@ -76,16 +76,19 @@ test("ignores a stale compatibility manifest when Nuxt config is newer", async (
       ".nuxt/doctor.manifest.json": JSON.stringify({
         generatedAt: "2000-01-01T00:00:00.000Z",
         compatibilityVersion: 4,
+        autoImportEnabled: true,
       }),
       "nuxt.config.ts":
         "export default defineNuxtConfig({ future: { compatibilityVersion: 5 } })\n",
     },
     async (root) => {
-      expect((await detectProject(root)).nuxtCompatibility).toMatchObject({
+      const project = await detectProject(root);
+      expect(project.nuxtCompatibility).toMatchObject({
         state: "resolved",
         version: 5,
         provenance: "config",
       });
+      expect(project.nuxt?.autoImportsAuthoritative).toBe(false);
     },
   );
 });
@@ -138,14 +141,17 @@ export default defineNuxtConfig(config)
           generatedAt: new Date(Math.floor(configMtimeMs)).toISOString(),
           nuxtConfigMtimeMs: configMtimeMs,
           compatibilityVersion: 5,
+          autoImportEnabled: true,
         }),
       );
 
-      expect((await detectProject(root)).nuxtCompatibility).toMatchObject({
+      const project = await detectProject(root);
+      expect(project.nuxtCompatibility).toMatchObject({
         state: "resolved",
         version: 5,
         provenance: "manifest",
       });
+      expect(project.nuxt?.autoImportsAuthoritative).toBe(true);
     },
   );
 });

--- a/tests/rule-packs/nuxt/e2e-fixtures.test.ts
+++ b/tests/rule-packs/nuxt/e2e-fixtures.test.ts
@@ -62,7 +62,6 @@ test("Nuxt all-issues fixture reports Nuxt and ecosystem rule packs", async () =
     "nuxt/hydration/no-client-conditional-in-template:app/components/IssuePanel.vue",
     "nuxt/hydration/prefer-usecookie-for-initial-client-state:app/components/IssuePanel.vue",
     "nuxt/imports/no-conflicting-usefetch-import:app/components/IssuePanel.vue",
-    "nuxt/imports/no-explicit-auto-import:app/components/IssuePanel.vue",
     "nuxt/middleware/no-route-middleware-api-security:app/middleware/auth.ts",
     "nuxt/plugins/no-subdir-auto-registration-assumption:app/plugins/nested/analytics.ts",
     "nuxt/project/prefer-app-directory-placement:pages/legacy.vue",

--- a/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
+++ b/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
@@ -2873,7 +2873,7 @@ test("explicit auto-import rule follows the resolved Nuxt registry and configura
   expect(portalImport).toHaveLength(1);
   expect(portalImport[0]).toMatchObject({
     ruleId: "nuxt/imports/no-explicit-auto-import",
-    severity: "info",
+    severity: "warn",
   });
   expect(portalImport[0]?.fix?.kind).toBe("safe");
 

--- a/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
+++ b/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
@@ -51,6 +51,7 @@ import {
   asyncDataExplicitKeyForRefreshable,
   postFetchRequiresReadonlyMarker,
   noMutationToastInUseFetchCallback,
+  noExplicitAutoImport,
 } from "../../../src/rule-packs/nuxt/rules/nuxt.ts";
 import {
   noBrowserApiInServer,
@@ -2812,6 +2813,119 @@ test("manifest plugin files suppress configured nested plugin warning", async ()
   );
 });
 
+test("explicit auto-import rule follows the resolved Nuxt registry and configuration", async () => {
+  async function runCase(
+    source: string,
+    manifest: Record<string, unknown> = {},
+    file = "app/components/Alerts/Shared/ListMessage.vue",
+    severity?: "error",
+  ) {
+    let diagnostics: Awaited<ReturnType<typeof runDoctor>>["diagnostics"] = [];
+    await withFixture(
+      {
+        [file]: `<script setup lang="ts">${source}</script>`,
+        "app/utils/alerts.ts": `export function getAlertListValue() { return '' }`,
+      },
+      {},
+      async (root) => {
+        await writeFileManifest(root, [], {
+          generatedAt: new Date().toISOString(),
+          autoImportEnabled: true,
+          autoImports: [
+            {
+              name: "getAlertListValue",
+              as: "getAlertListValue",
+              from: join(root, "app/utils/alerts.ts"),
+            },
+          ],
+          ...manifest,
+        });
+        const result = await runDoctor({
+          root,
+          framework: "nuxt",
+          config: severity
+            ? { rules: { "nuxt/imports/no-explicit-auto-import": severity } }
+            : undefined,
+          runtimeTarget: { nuxt: "4.0.0" },
+          extensions: [
+            defineDoctorExtension({
+              name: "fixture",
+              rulePacks: [
+                defineRulePack({
+                  name: "fixture",
+                  version: "0.0.0",
+                  rules: [noExplicitAutoImport],
+                  presets: { recommended: ["nuxt/imports/no-explicit-auto-import"] },
+                }),
+              ],
+            }),
+          ],
+        });
+        diagnostics = result.diagnostics;
+      },
+    );
+    return diagnostics;
+  }
+
+  const portalImport = await runCase(
+    `import { getAlertListValue } from '~/utils/alerts'\ngetAlertListValue()`,
+  );
+  expect(portalImport).toHaveLength(1);
+  expect(portalImport[0]).toMatchObject({
+    ruleId: "nuxt/imports/no-explicit-auto-import",
+    severity: "info",
+  });
+  expect(portalImport[0]?.fix?.kind).toBe("safe");
+
+  const blockingPortalImport = await runCase(
+    `import { getAlertListValue } from '#imports'\ngetAlertListValue()`,
+    {},
+    "app/components/Alerts/Shared/ListMessage.vue",
+    "error",
+  );
+  expect(blockingPortalImport[0]?.severity).toBe("error");
+
+  expect(
+    await runCase(`import { getAlertListValue } from 'other-package'\ngetAlertListValue()`),
+  ).toHaveLength(0);
+  expect(
+    await runCase(`import type { getAlertListValue } from '~/utils/alerts'`, {}, "app/types.ts"),
+  ).toHaveLength(0);
+  expect(
+    await runCase(`import { getAlertListValue as localValue } from '~/utils/alerts'\nlocalValue()`),
+  ).toHaveLength(0);
+  expect(
+    await runCase(
+      `import { getAlertListValue } from '~/utils/alerts'\ngetAlertListValue()`,
+      {},
+      "server/api/alerts.ts",
+    ),
+  ).toHaveLength(0);
+  expect(
+    await runCase(`import { getAlertListValue } from '~/utils/alerts'`, {
+      autoImportEnabled: false,
+    }),
+  ).toHaveLength(0);
+  expect(
+    await runCase(`import { getAlertListValue } from '~/utils/alerts'`, {
+      generatedAt: "invalid",
+    }),
+  ).toHaveLength(0);
+  expect(
+    await runCase(`import { getAlertListValue } from '~/utils/alerts'`, {
+      autoImportEnabled: undefined,
+    }),
+  ).toHaveLength(0);
+  expect(
+    await runCase(`import { getAlertListValue } from '~/utils/alerts'`, {
+      autoImportTransform: {
+        include: [],
+        exclude: [{ source: "ListMessage\\.vue$", flags: "" }],
+      },
+    }),
+  ).toHaveLength(0);
+});
+
 test("Nuxt module writes manifest and accepts context hook contributions", async () => {
   await withFixture({}, {}, async (root) => {
     const nuxt = {
@@ -2828,6 +2942,59 @@ test("Nuxt module writes manifest and accepts context hook contributions", async
     expect(existsSync(manifestPath)).toBe(true);
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
     expect(manifest.modules.some((module: any) => module.name === "fixture-module")).toBe(true);
+  });
+});
+
+test("Nuxt module records the resolved auto-import registry", async () => {
+  await withFixture({}, {}, async (root) => {
+    const hooks = new Map<string, Array<(payload: any) => unknown>>();
+    const nuxt = {
+      options: {
+        rootDir: root,
+        srcDir: "app",
+        buildDir: ".nuxt",
+        modules: [],
+        imports: {
+          autoImport: true,
+          imports: [],
+          transform: { exclude: [/generated/] },
+        },
+      },
+      hook(name: string, callback: (payload: any) => unknown) {
+        hooks.set(name, [...(hooks.get(name) ?? []), callback]);
+      },
+      async callHook() {},
+    };
+
+    await nuxtDoctorModule({}, nuxt);
+    for (const hook of hooks.get("imports:context") ?? [])
+      await hook({
+        getImports: async () => [
+          {
+            name: "getAlertListValue",
+            as: "getAlertListValue",
+            from: join(root, "app/utils/alerts.ts"),
+          },
+        ],
+      });
+    for (const hook of hooks.get("prepare:types") ?? []) await hook(undefined);
+
+    expect(
+      JSON.parse(readFileSync(join(root, ".nuxt/doctor.manifest.json"), "utf8")),
+    ).toMatchObject({
+      appDir: join(root, "app"),
+      autoImportEnabled: true,
+      autoImportTransform: {
+        exclude: [{ source: "generated", flags: "" }],
+      },
+      autoImports: [
+        {
+          name: "getAlertListValue",
+          as: "getAlertListValue",
+          from: join(root, "app/utils/alerts.ts"),
+        },
+      ],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- capture Nuxt's resolved auto-import registry in the Doctor manifest
- report redundant value imports only when implicit auto-importing is enabled and inventory is fresh
- respect aliases, transform exclusions, type imports, runtime boundaries, and rule severity overrides

## Verification

- `pnpm release:check` (288 tests)
- packed Portal PR #906 consumer: `NUXT0036` at `app/components/Alerts/Shared/ListMessage.vue:3`