### PR TITLE
feat: make Doctor runs agent-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ pnpm dlx vite-doctor . --rules nuxt/fetch/no-raw-fetch-in-setup
 pnpm dlx vite-doctor . --framework nitro
 ```
 
+`--changed` analyzes complete changed files for framework context, then reports only Diagnostics owned by staged, unstaged, or untracked lines:
+
+```bash
+pnpm dlx vite-doctor . --changed
+pnpm dlx vite-doctor . --since origin/main
+```
+
+Doctor recognizes coding-agent runtimes through Vercel's agent catalog and returns a compact agent report when output is non-interactive. An explicit format always wins:
+
+```bash
+pnpm dlx vite-doctor . --format text
+pnpm dlx vite-doctor . --format agent
+pnpm dlx vite-doctor . --format json
+pnpm dlx vite-doctor . --format sarif
+```
+
+Agent reports use relative locations and include remediation, Diagnostic Reference URLs, and command templates for explanation, focused verification, and the full rerun.
+
 For Nuxt projects, install Vite Doctor and run it through Nuxt:
 
 ```bash
@@ -53,7 +71,17 @@ The migration report stages source changes that are safe on the installed runtim
 
 ## Configuration
 
-Standalone trusted config files can use the full Doctor config shape:
+Doctor automatically loads declarative `doctor.config.json` without executing project code:
+
+```json
+{
+  "rules": {
+    "vite/define/no-secret-define": "error"
+  }
+}
+```
+
+Executable config remains explicit because loading it runs project code:
 
 ```ts
 // doctor.config.ts
@@ -64,6 +92,10 @@ export default defineDoctorConfig({
     "vite/define/no-secret-define": "error",
   },
 });
+```
+
+```bash
+pnpm dlx vite-doctor . --config doctor.config.ts
 ```
 
 Plugin surfaces accept the same policy through host config:

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -271,8 +271,8 @@ function toggleTheme() {
                   Nuxt 4.4.6 → Nitro 2.13.4 → H3 1.15.11
                 </p>
                 <p>
-                  <span class="text-neutral-500">Health score:</span>
-                  <span class="text-neutral-200">62/100</span>
+                  <span class="text-neutral-500">Confidence:</span>
+                  <span class="text-neutral-200"> 4 proven, 2 probable</span>
                 </p>
               </div>
               <div class="space-y-3 border-t border-white/[0.08] pt-3">

--- a/docs/content/1.cli.md
+++ b/docs/content/1.cli.md
@@ -25,6 +25,23 @@ pnpm dlx vite-doctor . --rules nuxt/fetch/no-raw-fetch-in-setup
 pnpm dlx vite-doctor . --fix
 ```
 
+`--changed` includes staged, unstaged, and untracked files against `HEAD`. `--since <ref>` uses the merge base with that ref. Doctor analyzes complete files and project evidence, but reports only Diagnostics whose source location overlaps changed lines. A Git failure stops the run instead of returning a false clean result.
+
+Safe fixes are applied atomically and Doctor runs again. The final report contains the remaining Diagnostics and a count of applied or skipped edits.
+
+## Use Doctor from an agent
+
+Doctor uses Vercel's agent catalog to recognize coding-agent runtimes. Non-interactive agent runs receive the compact agent report automatically. CI and interactive terminals keep text output. Pass an explicit format whenever a script needs a fixed contract:
+
+```bash
+pnpm dlx vite-doctor . --format agent
+pnpm dlx vite-doctor . --format json
+pnpm dlx vite-doctor . --format sarif
+pnpm dlx vite-doctor . --format text
+```
+
+The agent report removes duplicate fields but keeps a direct remediation path. Each Diagnostic includes its message, remediation, confidence, relative location, edit plan when available, and Diagnostic Reference URL. Top-level command templates cover explanation, focused verification, and the full rerun without repeating them for every finding.
+
 ## Check a migration before upgrading
 
 Use `migrate` to evaluate the current source against the next supported runtime graph:
@@ -51,7 +68,17 @@ pnpm dlx vite-doctor migrate . --to nuxt@5 --format json
 
 ## Configuration
 
-Use `doctor.config.ts` when you want a standalone trusted Doctor config:
+Doctor loads `doctor.config.json` automatically. This form is declarative and does not execute project code:
+
+```json [doctor.config.json]
+{
+  "rules": {
+    "vite/define/no-secret-define": "error"
+  }
+}
+```
+
+Use `doctor.config.ts` only when configuration needs code. Loading executable configuration is an explicit trust decision:
 
 ```ts [doctor.config.ts]
 import { defineDoctorConfig } from "vite-doctor/config";
@@ -61,6 +88,10 @@ export default defineDoctorConfig({
     "vite/define/no-secret-define": "error",
   },
 });
+```
+
+```bash
+pnpm dlx vite-doctor . --config doctor.config.ts
 ```
 
 When Doctor runs through a host integration, pass the same policy through the plugin surface:

--- a/docs/content/4.vite.md
+++ b/docs/content/4.vite.md
@@ -77,4 +77,4 @@ Open the rule page from the reported rule ID, make the smallest framework-safe e
 pnpm vite-doctor . --framework vite --rules vite/define/no-secret-define
 ```
 
-Run with `--format json` when an agent or CI job needs a machine-readable report.
+Doctor returns compact structured output automatically in recognized agent runtimes. Use `--format agent` for a fixed agent contract or `--format json` for the complete machine report.

--- a/docs/content/6.typescript.md
+++ b/docs/content/6.typescript.md
@@ -45,4 +45,4 @@ Use a TypeScript rule ID without selecting a framework:
 pnpm vite-doctor . --rules typescript/boundaries/no-unvalidated-deserialization
 ```
 
-Run with `--format json` when an agent or CI job needs a machine-readable report.
+Doctor returns compact structured output automatically in recognized agent runtimes. Use `--format agent` for a fixed agent contract or `--format json` for the complete machine report.

--- a/docs/skills/doctor/SKILL.md
+++ b/docs/skills/doctor/SKILL.md
@@ -33,17 +33,20 @@ The standalone CLI also works for Nuxt one-off runs, CI fallback, or monorepo sc
 
 ## Workflow
 
-1. Run Doctor against the target project or package; install dependencies first if needed.
-2. Read each Diagnostic Code, `why`, `fix`, docs URL, severity, confidence, and source location.
-3. Open `https://vite-doctor.onmax.me/diagnostics/CODE` before recommending remediation.
-4. Prefer the smallest fix that addresses the Diagnostic and preserves project conventions.
-5. Run the narrowest relevant verification after editing.
-6. Use `--format json` or `--format sarif` only when structured output is needed.
+1. Run `vite-doctor . --changed --format agent` from the target project or package. Use a full Doctor Run when the worktree has no Git baseline or the user asks for a project audit.
+2. Read `status`, `scope`, and every Diagnostic's code, message, remediation, confidence, relative location, evidence, and optional edit plan.
+3. Work only on Diagnostics owned by the requested change. Do not widen the task to unrelated findings.
+4. Apply the smallest fix that satisfies the remediation and preserves project conventions. Treat structured edit plans as proposed edits, not permission to skip review.
+5. Substitute the Diagnostic's Rule ID into `commands.verify` and run it after editing.
+6. Run the report's `next.rerun` command before finishing. Report remaining Diagnostics or incomplete evidence exactly.
+7. Use the Diagnostic Reference URL when the inline remediation is ambiguous or framework behavior needs confirmation. Routine fixes should not require network access.
 
 ## Rules
 
 - Use `vite-doctor` for Vite, Vue, Nitro, and Nuxt projects; do not invent framework-specific packages or binaries.
 - Treat Rule IDs as execution/filtering selectors.
 - Treat Diagnostic Codes as the stable remediation identity for docs, fixes, and user-facing explanations.
+- Prefer `--format agent` for remediation work. Use JSON for full run metadata and SARIF for code-scanning integrations.
+- An explicit `--format` is deterministic. Do not depend on automatic runtime recognition in scripts.
 - Use Doctor terms consistently: Doctor, Rule, Rule Pack, Diagnostic Code, and Diagnostic.
 - Keep code edits scoped to reported Diagnostics unless the user asks for broader cleanup.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "dist",
+    "docs/skills/doctor",
     "README.md"
   ],
   "type": "module",
@@ -72,6 +73,7 @@
     "cac": "catalog:prod",
     "consola": "catalog:prod",
     "defu": "catalog:prod",
+    "detect-agent": "catalog:prod",
     "eslint": "catalog:analysis",
     "eslint-plugin-vue": "catalog:analysis",
     "magic-string": "catalog:analysis",
@@ -80,6 +82,7 @@
     "pathe": "catalog:prod",
     "picocolors": "catalog:prod",
     "semver": "catalog:prod",
+    "std-env": "catalog:prod",
     "typescript": "catalog:analysis",
     "vue-eslint-parser": "catalog:analysis"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ catalogs:
     consola:
       specifier: ^3.4.2
       version: 3.4.2
+    detect-agent:
+      specifier: ^1.2.0
+      version: 1.2.0
     defu:
       specifier: ^6.1.7
       version: 6.1.7
@@ -179,6 +182,9 @@ importers:
       consola:
         specifier: catalog:prod
         version: 3.4.2
+      detect-agent:
+        specifier: catalog:prod
+        version: 1.2.0
       defu:
         specifier: catalog:prod
         version: 6.1.7
@@ -206,6 +212,9 @@ importers:
       semver:
         specifier: catalog:prod
         version: 7.8.5
+      std-env:
+        specifier: catalog:prod
+        version: 4.2.0
       typescript:
         specifier: catalog:analysis
         version: 6.0.3
@@ -5817,6 +5826,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  detect-agent@1.2.0:
+    resolution: {integrity: sha512-fW/515FHIogLopGDTSMc4XXkJV6mkVC10gVPoenb7cgY7PZAF/jakLDdDUBQ9QpJEA9AYgEg3/B9WqLTUtz3Ag==}
+    engines: {node: '>=20'}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -15073,6 +15086,8 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.7: {}
+
+  detect-agent@1.2.0: {}
 
   denque@2.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,7 @@ catalogs:
     c12: 4.0.0-beta.5
     cac: ^7.0.0
     consola: ^3.4.2
+    detect-agent: ^1.2.0
     defu: ^6.1.7
     pathe: ^2.0.3
     picocolors: ^1.1.1

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -1,4 +1,4 @@
-import { statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { cac } from "cac";
 import { consola } from "consola";
 import { resolve } from "pathe";
@@ -7,19 +7,21 @@ import {
   createReport,
   createRulesReport,
   explainRule,
+  loadDoctorConfig,
+  reportStatus,
+  type DoctorConfig,
+  type DoctorReportFormat,
   type DoctorRunOptions,
 } from "./core/index.js";
-import {
-  applyDoctorOptions,
-  normalizeDoctorCommand,
-  parseDoctorArgs,
-} from "./core/internal/cli.js";
+import { selectDoctorPresentation } from "./core/internal/agent-runtime.js";
+import { applyDoctorOptions, stringFlag } from "./core/internal/cli.js";
 import { runViteDoctor, shouldFailDoctorRun, viteDoctorRulePacks } from "./doctor.js";
 import { viteDoctorVersion } from "./version.js";
 import { createMigrationReport, formatMigrationReport } from "./migration.js";
 
-const commands = new Set(["scan", "check", "migrate", "rules", "explain", "cache"]);
-const removedCommands = new Set(["run", "ci"]);
+const removedCommands = new Set(["run", "ci", "scan", "check"]);
+const reportFormats = new Set<DoctorReportFormat>(["text", "json", "sarif", "agent"]);
+const metadataFormats = new Set<DoctorReportFormat>(["text", "json", "agent"]);
 
 export async function main(args = process.argv.slice(2), cwd = process.cwd()): Promise<number> {
   if (args.includes("--version") || args.includes("-v")) {
@@ -28,51 +30,62 @@ export async function main(args = process.argv.slice(2), cwd = process.cwd()): P
   }
 
   if (removedCommands.has(args[0] ?? "")) {
-    errorHuman(`vite-doctor ${args[0]} was removed. Use your package manager scripts directly.`);
-    return 1;
+    const command = args[0]!;
+    const replacement =
+      command === "scan" || command === "check"
+        ? "vite-doctor [path]"
+        : "your package manager scripts";
+    await writeCliError(
+      `vite-doctor ${command} was removed. Use ${replacement}.`,
+      await requestedPresentation(args),
+    );
+    return 2;
   }
 
   let exitCode = 0;
   const cli = cac("vite-doctor");
-  addScanCommand(cli, "scan", cwd, (code) => (exitCode = code));
-  addScanCommand(cli, "check", cwd, (code) => (exitCode = code));
+  addDoctorRunCommand(cli, cwd, (code) => (exitCode = code));
   cli
-    .command("migrate [path]", "Evaluate current source against a future runtime graph.")
+    .command("migrate [path]", "Evaluate source against a future runtime graph.")
     .option("--to <target>", "Explicit target such as nuxt@5 or nitro@3.")
-    .option("--format <format>", "Machine output: json.")
+    .option("--format <format>", "Output: text, json, or agent.")
     .action(async (path = ".", options) => {
+      const format = await presentationFormat(options.format, metadataFormats);
       const root = resolve(cwd, path);
-      const stat = statSync(root, { throwIfNoEntry: false });
-      if (!stat?.isDirectory()) {
-        errorHuman(`No readable directory found at ${root}`);
-        exitCode = 1;
+      if (!isDirectory(root)) {
+        await writeCliError(`No readable directory found at ${root}`, format);
+        exitCode = 2;
         return;
       }
       const report = await createMigrationReport(root, options.to ? [options.to] : []);
-      process.stdout.write(formatMigrationReport(report, options.format));
+      process.stdout.write(formatMigrationReport(report, format));
       exitCode = report.summary.errors > 0 ? 1 : 0;
     });
   cli
     .command("rules", "List available Doctor rules.")
-    .option("--format <format>", "Machine output: json or sarif.")
+    .option("--format <format>", "Output: text, json, or agent.")
     .option("--framework <framework>", "Framework override.")
     .action(async (options) => {
-      const runOptions: DoctorRunOptions = { root: cwd };
+      const format = await presentationFormat(options.format, metadataFormats);
+      const runOptions: DoctorRunOptions = { root: cwd, format };
       applyDoctorOptions(runOptions, options);
-      process.stdout.write(
-        createRulesReport(await viteDoctorRulePacks(runOptions), runOptions.format),
-      );
+      process.stdout.write(createRulesReport(await viteDoctorRulePacks(runOptions), format));
     });
   cli
-    .command("explain <rule>", "Explain a Doctor rule.")
-    .option("--format <format>", "Machine output: json or sarif.")
+    .command("explain <diagnostic>", "Explain a Doctor Diagnostic Code or Rule.")
+    .option("--format <format>", "Output: text, json, or agent.")
     .option("--framework <framework>", "Framework override.")
-    .action(async (rule: string, options) => {
-      const runOptions: DoctorRunOptions = { root: cwd };
+    .action(async (diagnostic: string, options) => {
+      const format = await presentationFormat(options.format, metadataFormats);
+      const runOptions: DoctorRunOptions = { root: cwd, format };
       applyDoctorOptions(runOptions, options);
-      process.stdout.write(
-        explainRule(await viteDoctorRulePacks(runOptions), rule, runOptions.format),
-      );
+      const report = explainRule(await viteDoctorRulePacks(runOptions), diagnostic, format);
+      if (!report) {
+        await writeCliError(`Unknown Diagnostic Code or Rule: ${diagnostic}`, format);
+        exitCode = 2;
+        return;
+      }
+      process.stdout.write(report);
     });
   cli.command("cache <action>", "Manage Doctor cache.").action((action: string) => {
     if (action === "clean") {
@@ -80,77 +93,160 @@ export async function main(args = process.argv.slice(2), cwd = process.cwd()): P
       consola.log("Doctor cache cleaned");
       return;
     }
-    consola.error(`Unknown cache command: ${action}`);
-    exitCode = 1;
+    throw new Error(`Unknown cache action: ${action}`);
   });
   cli.help();
 
   try {
-    cli.parse(["node", "vite-doctor", ...normalizeDoctorCommand(args, commands)], { run: false });
+    cli.parse(["node", "vite-doctor", ...args], { run: false });
     const result = await cli.runMatchedCommand();
     if (typeof result === "number") exitCode = result;
     return exitCode;
   } catch (error) {
-    consola.error(error instanceof Error ? error.message : String(error));
-    return 1;
+    const format = await requestedPresentation(args);
+    await writeCliError(error instanceof Error ? error.message : String(error), format);
+    return 2;
   }
 }
 
-function addScanCommand(
+function addDoctorRunCommand(
   cli: ReturnType<typeof cac>,
-  name: "scan" | "check",
   cwd: string,
   setExitCode: (code: number) => void,
 ) {
   cli
-    .command(`${name} [path]`, `Run ${name} diagnostics.`)
-    .option("--changed", "Only scan changed files.")
-    .option("--types", "Enable type-aware checks.")
+    .command("[path]", "Run Doctor diagnostics.")
+    .option("--changed", "Report diagnostics on changed lines.")
+    .option("--types", "Enable type-aware rules.")
     .option("--threads <threads>", "Thread count.")
     .option("--analyses <analyses>", "Analyses to run.")
     .option("--profile", "Include timings.")
-    .option("--new-only", "Only report new diagnostics.")
-    .option("--cache", "Use cache.")
-    .option("--no-cache", "Disable cache.")
-    .option("--fix", "Apply safe fixes.")
-    .option("--unsafe-fix", "Apply unsafe fixes.")
-    .option("--max-warnings <count>", "Maximum warnings.")
-    .option("--framework <framework>", "Framework override.")
-    .option("--rules <rules>", "Rule selector.")
-    .option("--severity <severity>", "Minimum severity.")
+    .option("--new-only", "Only report diagnostics absent from the baseline.")
+    .option("--cache", "Use the analysis cache.")
+    .option("--no-cache", "Disable the analysis cache.")
+    .option("--fix", "Apply safe edit plans and verify the result.")
+    .option("--unsafe-fix", "Apply unsafe edit plans and verify the result.")
+    .option("--max-warnings <count>", "Maximum warnings before failure.")
+    .option("--framework <framework>", "Framework override: vite, vue, nitro, or nuxt.")
+    .option("--rules <rules>", "Comma-separated Rule selectors.")
+    .option("--severity <severity>", "Minimum severity: error, warn, or info.")
     .option("--extends <extends>", "Comma-separated rule-pack presets.")
-    .option("--since <ref>", "Git base ref.")
-    .option("--baseline <file>", "Baseline file.")
-    .option("--format <format>", "Machine output: json or sarif.")
-    .option("--config", "Unsupported in vite-doctor.")
-    .option("--trusted-config", "Unsupported in vite-doctor.")
+    .option("--since <ref>", "Report diagnostics on lines changed since a Git ref.")
+    .option("--baseline <file>", "Diagnostic baseline file.")
+    .option("--format <format>", "Output: text, json, sarif, or agent.")
+    .option("--config <path>", "Explicitly load an executable Doctor config.")
     .action(async (path = ".", options) => {
-      const parsed = parseDoctorArgs([path]);
-      applyDoctorOptions(parsed.options, options);
-      if (options.config || options.trustedConfig) {
-        errorHuman(
-          "Executable config loading was removed from vite-doctor. Use built-in framework auto-activation or vite-doctor/config for trusted config files.",
-        );
-        setExitCode(1);
+      const format = await presentationFormat(options.format, reportFormats);
+      const root = resolve(cwd, path);
+      if (!isDirectory(root)) {
+        await writeCliError(`No readable directory found at ${root}`, format);
+        setExitCode(2);
         return;
       }
-      setExitCode(await runScan(parsed.path, parsed.options, cwd));
+      const runOptions: DoctorRunOptions = { root, format };
+      applyDoctorOptions(runOptions, options);
+      runOptions.config = await loadCliConfig(root, stringFlag(options.config));
+      setExitCode(await runDoctorCommand(runOptions, format));
     });
 }
 
-async function runScan(path: string, options: DoctorRunOptions, cwd: string): Promise<number> {
-  const root = resolve(cwd, path);
-  const stat = statSync(root, { throwIfNoEntry: false });
-  if (!stat?.isDirectory()) {
-    errorHuman(`No readable directory found at ${root}`);
-    return 1;
-  }
-  const result = await runViteDoctor({ ...options, root });
-  process.stdout.write(createReport(result, options.format));
+async function runDoctorCommand(
+  options: DoctorRunOptions,
+  format: DoctorReportFormat,
+): Promise<number> {
+  const result = await runViteDoctor(options);
+  process.stdout.write(createReport(result, format));
+  if (reportStatus(result) === "incomplete") return 3;
   return shouldFailDoctorRun(result, options.maxWarnings) ? 1 : 0;
 }
 
-function errorHuman(message: string) {
+async function loadCliConfig(
+  root: string,
+  explicitConfig?: string,
+): Promise<DoctorConfig | undefined> {
+  if (explicitConfig) {
+    return loadDoctorConfig({ cwd: root, configFile: resolve(root, explicitConfig) });
+  }
+  const declarativeConfig = resolve(root, "doctor.config.json");
+  if (!existsSync(declarativeConfig)) return undefined;
+  const value = JSON.parse(readFileSync(declarativeConfig, "utf8")) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("doctor.config.json must contain a JSON object.");
+  }
+  return value as DoctorConfig;
+}
+
+async function presentationFormat(
+  value: unknown,
+  supported: Set<DoctorReportFormat>,
+): Promise<DoctorReportFormat> {
+  const explicit = stringFlag(value);
+  if (explicit && !reportFormats.has(explicit as DoctorReportFormat)) {
+    throw new Error(
+      `Unknown report format ${JSON.stringify(explicit)}. Expected ${[...supported].join(", ")}.`,
+    );
+  }
+  if (explicit && !supported.has(explicit as DoctorReportFormat)) {
+    throw new Error(
+      `Report format ${JSON.stringify(explicit)} is not available here. Expected ${[...supported].join(", ")}.`,
+    );
+  }
+  return (await selectDoctorPresentation(explicit as DoctorReportFormat | undefined)).format;
+}
+
+async function requestedPresentation(args: string[]): Promise<DoctorReportFormat> {
+  let explicit: string | undefined;
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === "--format") explicit = args[index + 1];
+    else if (args[index]?.startsWith("--format="))
+      explicit = args[index]!.slice("--format=".length);
+  }
+  if (explicit && reportFormats.has(explicit as DoctorReportFormat)) {
+    return (await selectDoctorPresentation(explicit as DoctorReportFormat)).format;
+  }
+  return (await selectDoctorPresentation()).format;
+}
+
+async function writeCliError(message: string, format: DoctorReportFormat): Promise<void> {
+  if (format === "json" || format === "agent") {
+    const indentation = format === "agent" ? undefined : 2;
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          schema: format === "agent" ? "vite-doctor.agent/v1" : "vite-doctor.report/v3",
+          status: "failed",
+          error: { kind: "invocation", message },
+          next: { action: "correct-invocation", command: "vite-doctor --help" },
+        },
+        null,
+        indentation,
+      )}\n`,
+    );
+    return;
+  }
+  if (format === "sarif") {
+    process.stdout.write(
+      `${JSON.stringify({
+        version: "2.1.0",
+        runs: [
+          {
+            tool: { driver: { name: "Vite Doctor", semanticVersion: viteDoctorVersion } },
+            invocations: [
+              {
+                executionSuccessful: false,
+                toolExecutionNotifications: [{ level: "error", message: { text: message } }],
+              },
+            ],
+            results: [],
+          },
+        ],
+      })}\n`,
+    );
+    return;
+  }
   consola.error(message);
-  if (process.env.VITEST_WORKER_ID) console.error(message);
+}
+
+function isDirectory(path: string): boolean {
+  return Boolean(statSync(path, { throwIfNoEntry: false })?.isDirectory());
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -20,7 +20,7 @@ export interface DoctorRunOptions {
   extends?: "auto" | string[];
   changed?: boolean;
   since?: string;
-  format?: string;
+  format?: import("./primitives.js").DoctorReportFormat;
   baseline?: string;
   updateBaseline?: boolean;
   newOnly?: boolean;
@@ -51,11 +51,13 @@ export function defineDoctorConfig(config: DoctorConfig): DoctorConfig {
 export interface LoadDoctorConfigOptions {
   cwd: string;
   defaults?: DoctorConfig;
+  configFile?: string;
 }
 
 export async function loadDoctorConfig(options: LoadDoctorConfigOptions): Promise<DoctorConfig> {
   const result = await loadConfig<DoctorConfig>({
-    configFile: "doctor.config",
+    configFile: options.configFile ?? "doctor.config",
+    configFileRequired: Boolean(options.configFile),
     cwd: options.cwd,
     dotenv: false,
     globalRc: false,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -36,6 +36,22 @@ export { evaluatePackActivation, evaluateRuleApplicability } from "./internal/ap
 export { detectProject } from "./internal/project.js";
 
 export async function runDoctor(options: DoctorRunOptions = {}): Promise<DoctorRunResult> {
+  const requestedFixes = Boolean(options.fix || options.unsafeFix || options.structuralReview);
+  const initial = await executeDoctorRun(
+    requestedFixes && options.updateBaseline ? { ...options, updateBaseline: false } : options,
+  );
+  if (!requestedFixes || (!initial.fixes?.edits && !options.updateBaseline)) return initial;
+
+  const verified = await executeDoctorRun({
+    ...options,
+    fix: false,
+    unsafeFix: false,
+    structuralReview: false,
+  });
+  return { ...verified, fixes: initial.fixes };
+}
+
+async function executeDoctorRun(options: DoctorRunOptions): Promise<DoctorRunResult> {
   const session = await createScanSession(options);
   reportRuntimeInventoryUnknown(session);
   await runPhase(session, "parseFileFacts", () => parseSourceFiles(session));
@@ -47,8 +63,11 @@ export async function runDoctor(options: DoctorRunOptions = {}): Promise<DoctorR
   await runPhase(session, "typeRules", () => runTypeRules(session));
   await runPhase(session, "duplication", () => runDuplicationPhase(session));
   await runPhase(session, "health", () => runHealthPhase(session));
-  await runPhase(session, "fixPlanning", () => applyRequestedFixes(session));
   applyPolicyFilters(session);
+  let fixes: ReturnType<typeof applyRequestedFixes> = undefined;
+  await runPhase(session, "fixPlanning", () => {
+    fixes = applyRequestedFixes(session);
+  });
 
   const started = performance.now();
   const result = createResult(
@@ -60,7 +79,16 @@ export async function runDoctor(options: DoctorRunOptions = {}): Promise<DoctorR
     options.profile ? session.timings : undefined,
     options.profile ? session.phases : undefined,
     session.graph,
+    session.gitChanges
+      ? {
+          mode: "changed",
+          base: session.gitChanges.base,
+          files: session.files.length,
+          deletedFiles: session.gitChanges.files.filter((file) => file.kind === "deleted").length,
+        }
+      : { mode: "all", files: session.files.length },
   );
+  result.fixes = fixes;
   markSession(session, "score", started);
   return result;
 }

--- a/src/core/internal/agent-runtime.ts
+++ b/src/core/internal/agent-runtime.ts
@@ -1,0 +1,42 @@
+import { determineAgent, type AgentResult } from "detect-agent";
+import { isCI } from "std-env";
+import type { DoctorReportFormat } from "../primitives.js";
+
+export interface DoctorPresentation {
+  format: DoctorReportFormat;
+  detectedAgent?: string;
+  automatic: boolean;
+}
+
+interface AgentRuntime {
+  ci: boolean;
+  tty: boolean;
+  determineAgent: () => Promise<AgentResult>;
+}
+
+const currentRuntime: AgentRuntime = {
+  ci: isCI,
+  tty: process.stdout?.isTTY === true,
+  determineAgent,
+};
+
+export async function selectDoctorPresentation(
+  explicitFormat?: DoctorReportFormat,
+  runtime: AgentRuntime = currentRuntime,
+): Promise<DoctorPresentation> {
+  if (explicitFormat) return { format: explicitFormat, automatic: false };
+  if (runtime.ci || runtime.tty) return { format: "text", automatic: false };
+
+  try {
+    const result = await runtime.determineAgent();
+    if (result.isAgent) {
+      return {
+        format: "agent",
+        detectedAgent: result.agent.name,
+        automatic: true,
+      };
+    }
+  } catch {}
+
+  return { format: "text", automatic: false };
+}

--- a/src/core/internal/cli.ts
+++ b/src/core/internal/cli.ts
@@ -35,7 +35,7 @@ export function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
     else if (arg === "--extends") options.extends = parseExtends(args[++index]);
     else if (arg === "--since") options.since = args[++index];
     else if (arg === "--baseline") options.baseline = args[++index];
-    else if (arg === "--format") options.format = args[++index];
+    else if (arg === "--format") options.format = args[++index] as DoctorRunOptions["format"];
     else if (!arg.startsWith("-")) path = arg;
   }
   return { options, path };
@@ -71,7 +71,7 @@ export function applyDoctorOptions(
   options.extends = parseExtendsFlag(flags.extends) ?? options.extends;
   options.since = stringFlag(flags.since) ?? options.since;
   options.baseline = stringFlag(flags.baseline) ?? options.baseline;
-  options.format = stringFlag(flags.format) ?? options.format;
+  options.format = (stringFlag(flags.format) as DoctorRunOptions["format"]) ?? options.format;
 }
 
 function parseExtends(value: string | undefined): DoctorRunOptions["extends"] {

--- a/src/core/internal/diagnostics.ts
+++ b/src/core/internal/diagnostics.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "pathe";
 import MagicString from "magic-string";
 import type { DoctorConfig } from "../config.js";
@@ -19,22 +20,53 @@ import { codeForRuleId, diagnosticForCode } from "../diagnostics.js";
 import { doctorInternalDiagnostics } from "../internal-diagnostic-handles.js";
 import type { Diagnostic as NosticsDiagnostic } from "nostics";
 
-export function applyRequestedFixes(session: ScanSession): void {
+export interface AppliedFixes {
+  files: number;
+  edits: number;
+  skipped: number;
+}
+
+export function applyRequestedFixes(session: ScanSession): AppliedFixes | undefined {
   if (!session.options.fix && !session.options.unsafeFix && !session.options.structuralReview)
-    return;
+    return undefined;
   const started = performance.now();
-  applyFixes(session.diagnostics, {
+  const applied = applyFixes(session.diagnostics, {
     includeUnsafe: session.options.unsafeFix,
     includeStructuralReview: session.options.structuralReview,
   });
   markSession(session, "fix", started);
+  return applied;
 }
 
 export function applyPolicyFilters(session: ScanSession): void {
+  applyReportEligibility(session);
   applySeverityFilter(session);
   const result = applyDiagnosticPolicy(session);
   session.diagnostics = result.diagnostics;
   session.suppressedDiagnostics = result.suppressedDiagnostics;
+}
+
+export function applyReportEligibility(session: ScanSession): void {
+  if (!session.options.changed && !session.options.since) return;
+  const eligibility = new Map(
+    session.files.map((file) => [file.path, file.reportEligibility] as const),
+  );
+  const sources = new Map(session.handles.map((handle) => [handle.path, handle.text] as const));
+  session.diagnostics = session.diagnostics.filter((diagnostic) => {
+    const fileEligibility = eligibility.get(diagnostic.file);
+    if (!fileEligibility) return false;
+    if (!diagnostic.range) return false;
+    const endLine = diagnosticEndLine(diagnostic.range, sources.get(diagnostic.file));
+    return fileEligibility.ranges.some(
+      (range) => diagnostic.range!.line <= range.endLine && endLine >= range.startLine,
+    );
+  });
+}
+
+function diagnosticEndLine(range: NonNullable<Diagnostic["range"]>, source?: string): number {
+  if (!source || range.end <= range.start) return range.line;
+  const newlines = source.slice(range.start, range.end - 1).match(/\n/g)?.length ?? 0;
+  return range.line + newlines;
 }
 
 function applySeverityFilter(session: ScanSession): void {
@@ -56,7 +88,7 @@ function severityRank(severity: DoctorSeverity): number {
 function applyFixes(
   diagnostics: Diagnostic[],
   options: { includeUnsafe?: boolean; includeStructuralReview?: boolean } = {},
-) {
+): AppliedFixes {
   const byFile = new Map<string, Diagnostic[]>();
   for (const diagnostic of diagnostics) {
     if (!diagnostic.fix) continue;
@@ -67,14 +99,27 @@ function applyFixes(
     list.push(diagnostic);
     byFile.set(diagnostic.file, list);
   }
+  const applied: AppliedFixes = { files: 0, edits: 0, skipped: 0 };
   for (const [file, items] of byFile) {
     const text = readFileSync(file, "utf8");
     const ms = new MagicString(text);
+    const candidates = items.flatMap((item) => item.fix?.edits ?? []);
     const edits = planNonOverlappingFixes(items).sort((a, b) => b.range.start - a.range.start);
+    applied.skipped += candidates.length - edits.length;
+    if (!edits.length) continue;
     for (const edit of edits) ms.overwrite(edit.range.start, edit.range.end, edit.text);
     mkdirSync(dirname(file), { recursive: true });
-    writeFileSync(file, ms.toString());
+    const temporary = `${file}.vite-doctor-${process.pid}-${randomUUID()}.tmp`;
+    try {
+      writeFileSync(temporary, ms.toString(), { mode: statSync(file).mode });
+      renameSync(temporary, file);
+    } finally {
+      rmSync(temporary, { force: true });
+    }
+    applied.files++;
+    applied.edits += edits.length;
   }
+  return applied;
 }
 
 export function createResult(
@@ -86,13 +131,15 @@ export function createResult(
   timings?: Record<string, number>,
   phases?: Record<string, number>,
   graph?: WorkspaceGraph,
+  scope: DoctorRunResult["scope"] = { mode: "all", files: 0 },
 ): DoctorRunResult {
   const scoring = scoreDiagnostics(diagnostics, config);
   return {
     version: VERSION,
-    reportVersion: 2,
+    reportVersion: 3,
     framework: project.framework,
     root,
+    scope,
     score: scoring.score,
     categoryScores: scoring.categoryScores,
     summary: scoring.summary,

--- a/src/core/internal/git-change-ranges.ts
+++ b/src/core/internal/git-change-ranges.ts
@@ -1,0 +1,416 @@
+import { execFile } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { resolve } from "pathe";
+
+export type GitChangeKind =
+  | "added"
+  | "modified"
+  | "deleted"
+  | "renamed"
+  | "copied"
+  | "type-changed"
+  | "unmerged"
+  | "untracked";
+
+export interface GitChangeHunk {
+  previous: { startLine: number; lineCount: number };
+  current: { startLine: number; lineCount: number };
+}
+
+export interface ChangedLineRange {
+  startLine: number;
+  endLine: number;
+}
+
+export interface GitChangedFile {
+  kind: GitChangeKind;
+  path?: string;
+  previousPath?: string;
+  hunks: GitChangeHunk[];
+  reportRanges: ChangedLineRange[];
+}
+
+export type GitChangeUnavailableReason =
+  | "git-not-found"
+  | "not-a-repository"
+  | "missing-head"
+  | "invalid-ref"
+  | "no-merge-base"
+  | "git-command-failed";
+
+export interface AvailableGitChangeInventory {
+  status: "available";
+  base: string | null;
+  files: GitChangedFile[];
+}
+
+export interface UnavailableGitChangeInventory {
+  status: "unavailable";
+  reason: GitChangeUnavailableReason;
+  message: string;
+  ref?: string;
+}
+
+export type GitChangeInventory = AvailableGitChangeInventory | UnavailableGitChangeInventory;
+
+interface CommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  errorCode?: string;
+}
+
+interface TrackedChange {
+  kind: Exclude<GitChangeKind, "untracked">;
+  path?: string;
+  previousPath?: string;
+}
+
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+export async function collectGitChangeInventory(
+  root: string,
+  since?: string,
+  includePath: (path: string) => boolean = () => true,
+): Promise<GitChangeInventory> {
+  const repository = await runGit(root, ["rev-parse", "--is-inside-work-tree"]);
+  if (!repository.ok) {
+    return unavailableInventory(
+      repository.errorCode === "ENOENT" ? "git-not-found" : "not-a-repository",
+      repository.errorCode === "ENOENT"
+        ? "Git is not installed or is not available on PATH."
+        : "The Doctor Run root is not inside a Git worktree.",
+      since,
+    );
+  }
+  if (repository.stdout.trim() !== "true") {
+    return unavailableInventory(
+      "not-a-repository",
+      "The Doctor Run root is not inside a Git worktree.",
+      since,
+    );
+  }
+
+  const head = await runGit(root, ["rev-parse", "--verify", "HEAD"]);
+  if (!head.ok) {
+    if (since) {
+      return unavailableInventory(
+        "missing-head",
+        `Cannot resolve --since ${JSON.stringify(since)} because the repository has no HEAD commit.`,
+        since,
+      );
+    }
+    return collectUnbornRepositoryChanges(root, includePath);
+  }
+
+  const base = since ? await resolveMergeBase(root, since) : head.stdout.trim();
+  if (typeof base !== "string") return base;
+
+  const tracked = await runGit(root, [
+    "diff",
+    "--name-status",
+    "-z",
+    "--find-renames",
+    "--relative",
+    "--diff-filter=ACMRDTU",
+    base,
+    "--",
+  ]);
+  if (!tracked.ok) {
+    return unavailableInventory(
+      "git-command-failed",
+      commandFailureMessage("Git could not list changed files", tracked),
+      since,
+    );
+  }
+
+  const untracked = await listUntrackedFiles(root, since);
+  if (untracked.status === "unavailable") return untracked;
+
+  const changes: GitChangedFile[] = [];
+  for (const change of parseNameStatus(tracked.stdout).filter((change) =>
+    includePath(change.path ?? change.previousPath ?? ""),
+  )) {
+    const diffPath = change.path ?? change.previousPath;
+    const hunks = diffPath
+      ? await collectFileHunks(
+          root,
+          base,
+          diffPath,
+          change.path && change.previousPath ? change.previousPath : undefined,
+          since,
+        )
+      : { status: "available" as const, hunks: [] };
+    if (hunks.status === "unavailable") return hunks;
+    changes.push({
+      ...change,
+      hunks: hunks.hunks,
+      reportRanges: rangesFromHunks(hunks.hunks),
+    });
+  }
+
+  for (const path of untracked.paths.filter(includePath)) {
+    const lineCount = currentLineCount(resolve(root, path));
+    changes.push({
+      kind: "untracked",
+      path,
+      hunks: [
+        {
+          previous: { startLine: 0, lineCount: 0 },
+          current: { startLine: 1, lineCount },
+        },
+      ],
+      reportRanges: lineCount ? [{ startLine: 1, endLine: lineCount }] : [],
+    });
+  }
+
+  return {
+    status: "available",
+    base,
+    files: sortChanges(changes),
+  };
+}
+
+async function collectUnbornRepositoryChanges(
+  root: string,
+  includePath: (path: string) => boolean,
+): Promise<GitChangeInventory> {
+  const cached = await runGit(root, ["ls-files", "--cached", "-z", "--"]);
+  if (!cached.ok) {
+    return unavailableInventory(
+      "git-command-failed",
+      commandFailureMessage("Git could not list staged files", cached),
+    );
+  }
+  const untracked = await listUntrackedFiles(root);
+  if (untracked.status === "unavailable") return untracked;
+
+  const paths = [...new Set([...splitNull(cached.stdout), ...untracked.paths])]
+    .filter(includePath)
+    .filter((path) => statSync(resolve(root, path), { throwIfNoEntry: false })?.isFile())
+    .sort();
+  return {
+    status: "available",
+    base: null,
+    files: paths.map((path) => {
+      const lineCount = currentLineCount(resolve(root, path));
+      return {
+        kind: untracked.paths.includes(path) ? "untracked" : "added",
+        path,
+        hunks: [
+          {
+            previous: { startLine: 0, lineCount: 0 },
+            current: { startLine: 1, lineCount },
+          },
+        ],
+        reportRanges: lineCount ? [{ startLine: 1, endLine: lineCount }] : [],
+      };
+    }),
+  };
+}
+
+async function resolveMergeBase(
+  root: string,
+  ref: string,
+): Promise<string | UnavailableGitChangeInventory> {
+  const resolved = await runGit(root, [
+    "rev-parse",
+    "--verify",
+    "--end-of-options",
+    `${ref}^{commit}`,
+  ]);
+  if (!resolved.ok) {
+    return unavailableInventory(
+      "invalid-ref",
+      `Git ref ${JSON.stringify(ref)} does not exist.`,
+      ref,
+    );
+  }
+
+  const mergeBase = await runGit(root, ["merge-base", resolved.stdout.trim(), "HEAD"]);
+  if (!mergeBase.ok || !mergeBase.stdout.trim()) {
+    return unavailableInventory(
+      "no-merge-base",
+      `Git ref ${JSON.stringify(ref)} has no merge base with HEAD.`,
+      ref,
+    );
+  }
+  return mergeBase.stdout.trim();
+}
+
+async function listUntrackedFiles(
+  root: string,
+  ref?: string,
+): Promise<{ status: "available"; paths: string[] } | UnavailableGitChangeInventory> {
+  const result = await runGit(root, ["ls-files", "--others", "--exclude-standard", "-z", "--"]);
+  if (!result.ok) {
+    return unavailableInventory(
+      "git-command-failed",
+      commandFailureMessage("Git could not list untracked files", result),
+      ref,
+    );
+  }
+  return { status: "available", paths: splitNull(result.stdout).sort() };
+}
+
+async function collectFileHunks(
+  root: string,
+  base: string,
+  path: string,
+  previousPath?: string,
+  ref?: string,
+): Promise<{ status: "available"; hunks: GitChangeHunk[] } | UnavailableGitChangeInventory> {
+  const result = await runGit(root, [
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--no-ext-diff",
+    base,
+    "--",
+    ...(previousPath ? [previousPath] : []),
+    path,
+  ]);
+  if (!result.ok) {
+    return unavailableInventory(
+      "git-command-failed",
+      commandFailureMessage(`Git could not read changes for ${JSON.stringify(path)}`, result),
+      ref,
+    );
+  }
+  return { status: "available", hunks: parseHunks(result.stdout) };
+}
+
+export function parseGitChangeHunks(patch: string): GitChangeHunk[] {
+  return parseHunks(patch);
+}
+
+function parseHunks(patch: string): GitChangeHunk[] {
+  const hunks: GitChangeHunk[] = [];
+  for (const line of patch.split(/\r?\n/)) {
+    const match = HUNK_HEADER.exec(line);
+    if (!match) continue;
+    hunks.push({
+      previous: {
+        startLine: Number(match[1]),
+        lineCount: match[2] === undefined ? 1 : Number(match[2]),
+      },
+      current: {
+        startLine: Number(match[3]),
+        lineCount: match[4] === undefined ? 1 : Number(match[4]),
+      },
+    });
+  }
+  return hunks;
+}
+
+function rangesFromHunks(hunks: GitChangeHunk[]): ChangedLineRange[] {
+  const ranges = hunks
+    .filter((hunk) => hunk.current.lineCount > 0)
+    .map((hunk) => ({
+      startLine: hunk.current.startLine,
+      endLine: hunk.current.startLine + hunk.current.lineCount - 1,
+    }))
+    .sort((left, right) => left.startLine - right.startLine || left.endLine - right.endLine);
+
+  const merged: ChangedLineRange[] = [];
+  for (const range of ranges) {
+    const previous = merged.at(-1);
+    if (previous && range.startLine <= previous.endLine + 1) {
+      previous.endLine = Math.max(previous.endLine, range.endLine);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+  return merged;
+}
+
+function parseNameStatus(output: string): TrackedChange[] {
+  const fields = splitNull(output);
+  const changes: TrackedChange[] = [];
+  for (let index = 0; index < fields.length;) {
+    const status = fields[index++]!;
+    const code = status[0];
+    if (code === "R" || code === "C") {
+      const previousPath = fields[index++];
+      const path = fields[index++];
+      if (!previousPath || !path) continue;
+      changes.push({
+        kind: code === "R" ? "renamed" : "copied",
+        previousPath,
+        path,
+      });
+      continue;
+    }
+
+    const changedPath = fields[index++];
+    if (!changedPath) continue;
+    const kind = changeKind(code);
+    changes.push(
+      kind === "deleted" ? { kind, previousPath: changedPath } : { kind, path: changedPath },
+    );
+  }
+  return changes;
+}
+
+function changeKind(code: string | undefined): Exclude<GitChangeKind, "untracked"> {
+  if (code === "A") return "added";
+  if (code === "D") return "deleted";
+  if (code === "T") return "type-changed";
+  if (code === "U") return "unmerged";
+  return "modified";
+}
+
+function sortChanges(changes: GitChangedFile[]): GitChangedFile[] {
+  return changes.sort((left, right) => {
+    const leftPath = left.path ?? left.previousPath ?? "";
+    const rightPath = right.path ?? right.previousPath ?? "";
+    return compareText(leftPath, rightPath) || compareText(left.kind, right.kind);
+  });
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function currentLineCount(file: string): number {
+  const source = readFileSync(file, "utf8");
+  if (!source) return 0;
+  const newlineCount = source.match(/\n/g)?.length ?? 0;
+  return newlineCount + (source.endsWith("\n") ? 0 : 1);
+}
+
+function splitNull(value: string): string[] {
+  return value.split("\0").filter(Boolean);
+}
+
+function unavailableInventory(
+  reason: GitChangeUnavailableReason,
+  message: string,
+  ref?: string,
+): UnavailableGitChangeInventory {
+  return {
+    status: "unavailable",
+    reason,
+    message,
+    ...(ref ? { ref } : {}),
+  };
+}
+
+function commandFailureMessage(prefix: string, result: CommandResult): string {
+  const detail = result.stderr.trim();
+  return detail ? `${prefix}: ${detail}` : `${prefix}.`;
+}
+
+function runGit(root: string, args: string[]): Promise<CommandResult> {
+  return new Promise((resolvePromise) => {
+    execFile("git", args, { cwd: root, encoding: "utf8" }, (error, stdout, stderr) => {
+      resolvePromise({
+        ok: !error,
+        stdout,
+        stderr,
+        errorCode:
+          error && "code" in error && typeof error.code === "string" ? error.code : undefined,
+      });
+    });
+  });
+}

--- a/src/core/internal/scan-session.ts
+++ b/src/core/internal/scan-session.ts
@@ -18,7 +18,12 @@ import {
   type WorkspaceGraph,
 } from "../primitives.js";
 import { detectProject } from "./project.js";
-import { selectScanFiles, type ScanFileEntry } from "./source-inventory.js";
+import {
+  GitChangeUnavailableError,
+  selectSourceInventory,
+  type ScanFileEntry,
+} from "./source-inventory.js";
+import type { AvailableGitChangeInventory } from "./git-change-ranges.js";
 import { createHelpers } from "./doctor-helpers.js";
 import { VERSION, nativeMatch, sha256 } from "./utils.js";
 import { doctorInternalDiagnostics } from "../internal-diagnostic-handles.js";
@@ -87,6 +92,7 @@ export interface ScanSession {
   registry: RuleRegistry;
   project: ProjectInfo;
   files: ScanFileEntry[];
+  gitChanges?: AvailableGitChangeInventory;
   handles: SourceFileHandle[];
   facts: FileFacts[];
   graph?: WorkspaceGraph;
@@ -137,7 +143,11 @@ export async function createScanSession(options: DoctorRunOptions): Promise<Scan
   markSession(sessionBase, "project", started);
 
   started = performance.now();
-  const files = await selectScanFiles(root, config, options, project);
+  const sourceInventory = await selectSourceInventory(root, config, options, project);
+  if (sourceInventory.git?.status === "unavailable") {
+    throw new GitChangeUnavailableError(sourceInventory.git);
+  }
+  const files = sourceInventory.files;
   markSession(sessionBase, "files", started);
 
   const helpers = createHelpers();
@@ -146,6 +156,7 @@ export async function createScanSession(options: DoctorRunOptions): Promise<Scan
     registry,
     project,
     files,
+    gitChanges: sourceInventory.git,
     handles: [],
     facts: [],
     diagnostics: [],

--- a/src/core/internal/source-inventory.ts
+++ b/src/core/internal/source-inventory.ts
@@ -1,10 +1,17 @@
-import { execFile } from "node:child_process";
 import { closeSync, openSync, readSync, statSync } from "node:fs";
 import { glob } from "node:fs/promises";
+import { matchesGlob } from "node:path";
 import { relative, resolve } from "pathe";
 import type { DoctorConfig } from "../config.js";
 import type { DoctorRunOptions } from "../config.js";
 import type { ProjectInfo, SourceFileHandle } from "../primitives.js";
+import {
+  collectGitChangeInventory,
+  type AvailableGitChangeInventory,
+  type ChangedLineRange,
+  type GitChangeInventory,
+  type UnavailableGitChangeInventory,
+} from "./git-change-ranges.js";
 
 const DEFAULT_INCLUDE = [
   "**/*.{vue,ts,tsx,mts,cts,js,jsx,mjs,cjs}",
@@ -35,6 +42,48 @@ export interface ScanFileEntry {
   displayPath: string;
   sourceKind: SourceFileHandle["sourceKind"];
   moduleName?: string;
+  reportEligibility?: {
+    kind: "changed-lines";
+    ranges: ChangedLineRange[];
+  };
+}
+
+export interface SourceInventorySelection {
+  files: ScanFileEntry[];
+  git?: GitChangeInventory;
+}
+
+export class GitChangeUnavailableError extends Error {
+  readonly inventory: UnavailableGitChangeInventory;
+
+  constructor(inventory: UnavailableGitChangeInventory) {
+    super(inventory.message);
+    this.name = "GitChangeUnavailableError";
+    this.inventory = inventory;
+  }
+}
+
+export async function selectSourceInventory(
+  root: string,
+  config: DoctorConfig,
+  options: DoctorRunOptions,
+  project: ProjectInfo,
+): Promise<SourceInventorySelection> {
+  if (options.changed || options.since) {
+    const include = config.include ?? defaultIncludeForProject(project);
+    const exclude = [...DEFAULT_EXCLUDE, ...(config.exclude ?? [])];
+    const git = await collectGitChangeInventory(
+      root,
+      options.since,
+      (path) =>
+        include.some((pattern) => matchesGlob(path, pattern)) &&
+        !exclude.some((pattern) => matchesGlob(path, pattern)),
+    );
+    if (git.status === "unavailable") return { files: [], git };
+    return { files: selectChangedFiles(root, config, project, git), git };
+  }
+
+  return { files: await selectAllFiles(root, config, project) };
 }
 
 export async function selectScanFiles(
@@ -43,19 +92,18 @@ export async function selectScanFiles(
   options: DoctorRunOptions,
   project: ProjectInfo,
 ): Promise<ScanFileEntry[]> {
-  if (options.changed || options.since) {
-    const changed = await gitChangedFiles(root, options.since);
-    const includeContent = hasContentFiles(project);
-    return changed
-      .filter((file) =>
-        includeContent
-          ? /\.(vue|[cm]?[jt]sx?|mdc?)$/.test(file)
-          : /\.(vue|[cm]?[jt]sx?)$/.test(file),
-      )
-      .filter((file) => isScannableFile(resolve(root, file)))
-      .map((file) => createAppFileEntry(root, file));
+  const selection = await selectSourceInventory(root, config, options, project);
+  if (selection.git?.status === "unavailable") {
+    throw new GitChangeUnavailableError(selection.git);
   }
+  return selection.files;
+}
 
+async function selectAllFiles(
+  root: string,
+  config: DoctorConfig,
+  project: ProjectInfo,
+): Promise<ScanFileEntry[]> {
   const files = new Map<string, ScanFileEntry>();
   const exclude = [...DEFAULT_EXCLUDE, ...(config.exclude ?? [])];
   const include = config.include ?? defaultIncludeForProject(project);
@@ -86,6 +134,32 @@ export async function selectScanFiles(
   }
 
   return [...files.values()].sort((a, b) => a.displayPath.localeCompare(b.displayPath));
+}
+
+function selectChangedFiles(
+  root: string,
+  config: DoctorConfig,
+  project: ProjectInfo,
+  git: AvailableGitChangeInventory,
+): ScanFileEntry[] {
+  const include = config.include ?? defaultIncludeForProject(project);
+  const exclude = [...DEFAULT_EXCLUDE, ...(config.exclude ?? [])];
+  return git.files
+    .filter((change) => change.path)
+    .filter(
+      (change) =>
+        include.some((pattern) => matchesGlob(change.path!, pattern)) &&
+        !exclude.some((pattern) => matchesGlob(change.path!, pattern)),
+    )
+    .filter((change) => isScannableFile(resolve(root, change.path!)))
+    .map((change) => ({
+      ...createAppFileEntry(root, change.path!),
+      reportEligibility: {
+        kind: "changed-lines" as const,
+        ranges: change.reportRanges,
+      },
+    }))
+    .sort((left, right) => left.displayPath.localeCompare(right.displayPath));
 }
 
 function isScannableFile(file: string): boolean {
@@ -125,21 +199,4 @@ function createAppFileEntry(root: string, file: string): ScanFileEntry {
 function detectAppSourceKind(root: string, file: string): SourceFileHandle["sourceKind"] {
   const relativePath = relative(root, file);
   return relativePath.startsWith("layers/") ? "layer" : "app";
-}
-
-async function gitChangedFiles(root: string, since?: string): Promise<string[]> {
-  const args = since
-    ? ["diff", "--name-only", "--diff-filter=ACMR", since, "--"]
-    : ["diff", "--name-only", "--diff-filter=ACMR", "--cached", "--"];
-  const stdout = await execFileText("git", args, root);
-  return stdout.split(/\r?\n/).filter(Boolean);
-}
-
-function execFileText(command: string, args: string[], cwd: string): Promise<string> {
-  return new Promise((resolvePromise, reject) => {
-    execFile(command, args, { cwd, encoding: "utf8" }, (error, stdout) => {
-      if (error) reject(error);
-      else resolvePromise(stdout);
-    });
-  });
 }

--- a/src/core/primitives.ts
+++ b/src/core/primitives.ts
@@ -3,6 +3,7 @@ import { doctorInternalDiagnostics } from "./internal-diagnostic-handles.js";
 export { DOCTOR_DIAGNOSTICS_DOCS_BASE } from "./diagnostic-constants.js";
 
 export type DoctorSeverity = "blocker" | "error" | "warn" | "info";
+export type DoctorReportFormat = "text" | "json" | "sarif" | "agent";
 export type DoctorRuleConfig = "off" | DoctorSeverity | [DoctorSeverity, unknown];
 export interface DoctorSerializableConfig {
   extends?: "auto" | string[];
@@ -588,9 +589,15 @@ export interface RulePack {
 
 export interface DoctorRunResult {
   version: string;
-  reportVersion?: 2;
+  reportVersion?: 3;
   framework: DoctorFramework;
   root: string;
+  scope: {
+    mode: "all" | "changed";
+    base?: string | null;
+    files: number;
+    deletedFiles?: number;
+  };
   score: number;
   categoryScores: Record<string, number>;
   summary: {
@@ -602,6 +609,11 @@ export interface DoctorRunResult {
   };
   diagnostics: Diagnostic[];
   suppressedDiagnostics?: Diagnostic[];
+  fixes?: {
+    files: number;
+    edits: number;
+    skipped: number;
+  };
   timings?: Record<string, number>;
   phases?: Record<string, number>;
   graph?: {

--- a/src/core/reports.ts
+++ b/src/core/reports.ts
@@ -1,19 +1,30 @@
 import { relative } from "pathe";
 import pc from "picocolors";
 import { formatDiagnostic } from "nostics";
-import type { Diagnostic, DoctorRunResult, RulePack } from "./primitives.js";
+import type {
+  Confidence,
+  Diagnostic,
+  DoctorReportFormat,
+  DoctorRunResult,
+  RulePack,
+} from "./primitives.js";
 import { allDiagnosticCodesByRuleId } from "./diagnostic-code-map.js";
+import { DOCTOR_DIAGNOSTICS_DOCS_BASE } from "./diagnostic-constants.js";
 import { codeForRuleId } from "./diagnostics.js";
 
 export function createTextReport(result: DoctorRunResult): string {
   const lines: string[] = [];
+  const status = reportStatus(result);
   lines.push(`Detected: ${frameworkLabel(result)}`);
-  lines.push(`Workspace: ${result.root}`);
+  lines.push(`Project: ${result.root}`);
+  if (status === "incomplete") {
+    lines.push("Status: incomplete, runtime evidence could not be resolved");
+  }
   for (const edge of result.project.runtimeGraph?.edges ?? []) {
     const runtime = result.project.runtimeGraph?.packages[edge.to];
     const identity =
       runtime?.state === "resolved"
-        ? `${runtime.name}@${runtime.version}${runtime.packageJsonPath ? ` (${runtime.packageJsonPath})` : ""}`
+        ? `${runtime.name}@${runtime.version}`
         : `unknown${runtime?.reason ? ` (${runtime.reason})` : ""}`;
     lines.push(`Runtime: ${edge.from} -> ${edge.to} ${identity}`);
   }
@@ -22,7 +33,6 @@ export function createTextReport(result: DoctorRunResult): string {
       `Nuxt compatibility: ${result.project.nuxtCompatibility.state === "resolved" ? result.project.nuxtCompatibility.version : "unknown"} (${result.project.nuxtCompatibility.provenance})`,
     );
   }
-  lines.push(`Health score: ${result.score}/100`);
   if (result.project.nuxt?.manifest) {
     const evidence = result.project.nuxt.manifest.evidence;
     lines.push(
@@ -33,18 +43,25 @@ export function createTextReport(result: DoctorRunResult): string {
   lines.push(
     `Confidence mix: ${confidence.proven} proven, ${confidence.probable} probable, ${confidence.sourceOnly} source-only`,
   );
+  if (result.fixes?.edits) {
+    lines.push(
+      `Fixes applied: ${result.fixes.edits} edits in ${result.fixes.files} files${result.fixes.skipped ? `, ${result.fixes.skipped} skipped` : ""}`,
+    );
+  }
   lines.push("");
   for (const severity of ["blocker", "error", "warn", "info"] as const) {
-    const items = result.diagnostics.filter((d) => d.severity === severity);
+    const items = result.diagnostics.filter((diagnostic) => diagnostic.severity === severity);
     if (!items.length) continue;
     lines.push(pc.bold(labelSeverity(severity)));
     for (const diagnostic of items) {
+      const path = relative(result.root, diagnostic.file) || ".";
       const loc = diagnostic.range
-        ? `${diagnostic.file}:${diagnostic.range.line}:${diagnostic.range.column}`
-        : diagnostic.file;
+        ? `${path}:${diagnostic.range.line}:${diagnostic.range.column}`
+        : path;
       lines.push(indent(formatDiagnostic(diagnostic.diagnostic), "  "));
       lines.push(`    rule: ${diagnostic.ruleId}`);
       lines.push(`    source: ${loc}`);
+      lines.push(`    confidence: ${diagnostic.confidence ?? "heuristic-medium"}`);
     }
     lines.push("");
   }
@@ -70,33 +87,41 @@ export function createTextReport(result: DoctorRunResult): string {
 
 function confidenceMix(result: DoctorRunResult) {
   const mix = { proven: 0, probable: 0, sourceOnly: 0 };
-  const hasBuildEvidence = Boolean(result.project.nuxt?.manifest?.evidence?.buildManifest);
   for (const diagnostic of result.diagnostics) {
-    if (
-      diagnostic.severity === "info" ||
-      (!hasBuildEvidence &&
-        diagnostic.severity === "warn" &&
-        /(?:browser-global|time-dependent|random-or-local-time)/.test(diagnostic.ruleId))
-    )
-      mix.sourceOnly++;
-    else if (diagnostic.severity === "blocker" || diagnostic.severity === "error") mix.proven++;
-    else mix.probable++;
+    const confidence = diagnostic.confidence ?? "heuristic-medium";
+    if (isEvidenceBacked(confidence)) mix.proven++;
+    else if (confidence === "heuristic-high") mix.probable++;
+    else mix.sourceOnly++;
   }
   return mix;
+}
+
+function isEvidenceBacked(confidence: Confidence) {
+  return (
+    confidence === "proven" ||
+    confidence === "type-backed" ||
+    confidence === "manifest-backed" ||
+    confidence === "runtime-backed"
+  );
 }
 
 export function createJsonReport(result: DoctorRunResult): string {
   return `${JSON.stringify(
     {
       version: result.version,
-      reportVersion: result.reportVersion ?? 2,
+      reportVersion: result.reportVersion ?? 3,
+      status: reportStatus(result),
       framework: result.framework,
       root: result.root,
+      scope: result.scope,
+      summary: result.summary,
+      diagnostics: result.diagnostics.map((diagnostic) => serializeDiagnostic(result, diagnostic)),
+      suppressedDiagnostics: result.suppressedDiagnostics?.map((diagnostic) =>
+        serializeDiagnostic(result, diagnostic),
+      ),
+      fixes: result.fixes,
       score: result.score,
       categoryScores: result.categoryScores,
-      summary: result.summary,
-      diagnostics: result.diagnostics.map(serializeDiagnostic),
-      suppressedDiagnostics: result.suppressedDiagnostics?.map(serializeDiagnostic),
       timings: result.timings,
       phases: result.phases,
       graph: result.graph,
@@ -106,6 +131,47 @@ export function createJsonReport(result: DoctorRunResult): string {
     null,
     2,
   )}\n`;
+}
+
+export function createAgentReport(result: DoctorRunResult): string {
+  const status = reportStatus(result);
+  return `${JSON.stringify({
+    schema: "vite-doctor.agent/v1",
+    status,
+    project: {
+      cwd: result.root,
+      framework: result.framework,
+    },
+    scope: result.scope,
+    summary: result.summary,
+    diagnostics: result.diagnostics.map((diagnostic) =>
+      serializeAgentDiagnostic(result, diagnostic),
+    ),
+    fixes: result.fixes,
+    commands: {
+      explain: "vite-doctor explain <code> --format agent",
+      verify: "vite-doctor . --rules <rule> --format agent",
+      rerun: "vite-doctor . --format agent",
+    },
+    next:
+      status === "clean"
+        ? { action: "none" }
+        : status === "incomplete"
+          ? {
+              action: "restore-evidence",
+              instruction:
+                "Install project dependencies and run Doctor from the target package before relying on version-specific results.",
+              cwd: result.root,
+              rerun: "vite-doctor . --format agent",
+            }
+          : {
+              action: "remediate",
+              instruction:
+                "Apply the smallest remediation that resolves each owned diagnostic, run its focused verification, then rerun Doctor.",
+              cwd: result.root,
+              rerun: "vite-doctor . --format agent",
+            },
+  })}\n`;
 }
 
 export function createSarifReport(result: DoctorRunResult): string {
@@ -119,12 +185,13 @@ export function createSarifReport(result: DoctorRunResult): string {
         {
           tool: {
             driver: {
-              name: doctorName(result),
+              name: "Vite Doctor",
               semanticVersion: result.version,
               rules: [...rules.values()].map((diagnostic) => ({
                 id: diagnostic.ruleId,
                 name: diagnostic.code,
                 shortDescription: { text: diagnostic.code },
+                helpUri: diagnosticReferenceUrl(diagnostic.code),
                 properties: {
                   diagnosticCode: diagnostic.code,
                   category: diagnostic.category,
@@ -140,13 +207,12 @@ export function createSarifReport(result: DoctorRunResult): string {
             level: sarifLevel(diagnostic.severity),
             message: { text: diagnostic.why },
             partialFingerprints: {
-              "vue-doctor/v1": diagnostic.fingerprint,
-              "vue-doctor/v2": diagnostic.fingerprint,
+              "vite-doctor/v1": diagnostic.fingerprint,
             },
             properties: {
               confidence: diagnostic.confidence,
               diagnosticCode: diagnostic.code,
-              docs: diagnostic.docs,
+              docs: diagnosticReferenceUrl(diagnostic.code),
               evidenceKinds: diagnostic.evidence?.map((item) => item.kind),
               analysisPhase: diagnostic.analysisPhase,
             },
@@ -181,28 +247,14 @@ export function createSarifReport(result: DoctorRunResult): string {
   )}\n`;
 }
 
-function frameworkLabel(result: DoctorRunResult): string {
-  if (result.project.framework === "nuxt")
-    return `Nuxt ${result.project.nuxtVersion ?? "4"} + Vue ${result.project.vueVersion}`;
-  if (result.project.framework === "vite") return "Vite";
-  if (result.project.framework === "nitro") return "Nitro";
-  return `Vue ${result.project.vueVersion}`;
-}
-
-function doctorName(result: DoctorRunResult): string {
-  if (result.framework === "nuxt") return "Nuxt Doctor";
-  if (result.framework === "vite") return "Vite Doctor";
-  if (result.framework === "nitro") return "Nitro Doctor";
-  return "Vue Doctor";
-}
-
-export function createReport(result: DoctorRunResult, format = "text"): string {
+export function createReport(result: DoctorRunResult, format: DoctorReportFormat = "text"): string {
   if (format === "json") return createJsonReport(result);
   if (format === "sarif") return createSarifReport(result);
+  if (format === "agent") return createAgentReport(result);
   return `${createTextReport(result)}\n`;
 }
 
-export function createRulesReport(packs: RulePack[], format = "text"): string {
+export function createRulesReport(packs: RulePack[], format: DoctorReportFormat = "text"): string {
   const rules = packs.flatMap((pack) =>
     pack.rules.map((rule) => ({
       pack: pack.name,
@@ -212,6 +264,9 @@ export function createRulesReport(packs: RulePack[], format = "text"): string {
     })),
   );
   if (format === "json") return `${JSON.stringify({ rules }, null, 2)}\n`;
+  if (format === "agent") {
+    return `${JSON.stringify({ schema: "vite-doctor.rules/v1", status: "ready", rules })}\n`;
+  }
   const lines: string[] = [];
   for (const pack of packs) {
     lines.push(pack.name);
@@ -220,7 +275,11 @@ export function createRulesReport(packs: RulePack[], format = "text"): string {
   return `${lines.join("\n")}\n`;
 }
 
-export function explainRule(packs: RulePack[], ruleId: string, format = "text"): string {
+export function explainRule(
+  packs: RulePack[],
+  ruleId: string,
+  format: DoctorReportFormat = "text",
+): string {
   const match = packs
     .flatMap((pack) => pack.rules.map((rule) => ({ pack: pack.name, rule })))
     .find(
@@ -229,13 +288,18 @@ export function explainRule(packs: RulePack[], ruleId: string, format = "text"):
         item.rule.meta.diagnosticCodes?.includes(ruleId) ||
         codeListForRule(item.rule.meta.id).includes(ruleId),
     );
-  if (!match) return format === "json" ? `${JSON.stringify({ rule: null }, null, 2)}\n` : "";
+  if (!match) return "";
+  const diagnosticCodes = match.rule.meta.diagnosticCodes ?? codeListForRule(match.rule.meta.id);
   const payload = {
     pack: match.pack,
-    diagnosticCodes: match.rule.meta.diagnosticCodes ?? codeListForRule(match.rule.meta.id),
+    diagnosticCodes,
+    diagnostics: diagnosticCodes.map((code) => ({ code, docs: diagnosticReferenceUrl(code) })),
     ...match.rule.meta,
   };
   if (format === "json") return `${JSON.stringify(payload, null, 2)}\n`;
+  if (format === "agent") {
+    return `${JSON.stringify({ schema: "vite-doctor.explain/v1", status: "ready", ...payload })}\n`;
+  }
   const meta = match.rule.meta;
   return (
     [
@@ -244,12 +308,113 @@ export function explainRule(packs: RulePack[], ruleId: string, format = "text"):
       meta.description,
       meta.why ? `Why: ${meta.why}` : undefined,
       meta.recommendedReplacement ? `Prefer: ${meta.recommendedReplacement}` : undefined,
-      meta.docsUrl ? `Docs: ${meta.docsUrl}` : undefined,
-      `Diagnostics: ${(meta.diagnosticCodes ?? codeListForRule(meta.id)).join(", ")}`,
+      `Diagnostics: ${diagnosticCodes.join(", ")}`,
+      ...diagnosticCodes.map((code) => `Docs: ${diagnosticReferenceUrl(code)}`),
     ]
       .filter(Boolean)
       .join("\n") + "\n"
   );
+}
+
+export function reportStatus(result: DoctorRunResult): "clean" | "findings" | "incomplete" {
+  const expectedRuntimes =
+    result.framework === "nuxt"
+      ? (["nuxt", "nitro", "h3"] as const)
+      : result.framework === "nitro"
+        ? (["nitro", "h3"] as const)
+        : result.framework === "vue"
+          ? (["vue"] as const)
+          : [];
+  const unresolvedRuntime = expectedRuntimes.some(
+    (runtime) => result.project.runtimeGraph?.packages[runtime]?.state === "unknown",
+  );
+  if (unresolvedRuntime || result.project.nuxtCompatibility?.state === "unknown") {
+    return "incomplete";
+  }
+  return result.diagnostics.length > 0 ? "findings" : "clean";
+}
+
+function serializeDiagnostic(result: DoctorRunResult, diagnostic: Diagnostic) {
+  return {
+    fingerprint: diagnostic.fingerprint,
+    code: diagnostic.code,
+    rule: diagnostic.ruleId,
+    severity: diagnostic.severity,
+    confidence: diagnostic.confidence ?? "heuristic-medium",
+    category: diagnostic.category,
+    message: diagnostic.why,
+    remediation: diagnostic.diagnostic.fix,
+    docs: diagnosticReferenceUrl(diagnostic.code),
+    location: {
+      path: relative(result.root, diagnostic.file),
+      ...(diagnostic.range
+        ? {
+            line: diagnostic.range.line,
+            column: diagnostic.range.column,
+            start: diagnostic.range.start,
+            end: diagnostic.range.end,
+          }
+        : {}),
+    },
+    evidence: diagnostic.evidence?.map((item) => ({
+      kind: item.kind,
+      summary: item.summary,
+      path: item.file ? relative(result.root, item.file) : undefined,
+      range: item.range,
+      relatedId: item.relatedId,
+    })),
+    editPlan: diagnostic.fix,
+    related: diagnostic.related?.map((item) => ({
+      path: relative(result.root, item.file),
+      range: item.range,
+      message: item.message,
+    })),
+    suppression: diagnostic.suppressed
+      ? { suppressed: true, reason: diagnostic.suppressionReason }
+      : undefined,
+    analysis: diagnostic.analysisPhase,
+  };
+}
+
+function serializeAgentDiagnostic(result: DoctorRunResult, diagnostic: Diagnostic) {
+  const evidence = diagnostic.evidence
+    ?.filter((item) => item.summary !== "file analysis")
+    .map((item) => ({
+      kind: item.kind,
+      summary: item.summary,
+      path: item.file ? relative(result.root, item.file) : undefined,
+      range: item.range,
+      relatedId: item.relatedId,
+    }));
+  return {
+    fingerprint: diagnostic.fingerprint,
+    code: diagnostic.code,
+    rule: diagnostic.ruleId,
+    severity: diagnostic.severity,
+    confidence: diagnostic.confidence ?? "heuristic-medium",
+    location: {
+      path: relative(result.root, diagnostic.file),
+      line: diagnostic.range?.line,
+      column: diagnostic.range?.column,
+    },
+    message: diagnostic.why,
+    remediation: diagnostic.diagnostic.fix,
+    docs: diagnosticReferenceUrl(diagnostic.code),
+    evidence: evidence?.length ? evidence : undefined,
+    editPlan: diagnostic.fix,
+  };
+}
+
+function diagnosticReferenceUrl(code: string) {
+  return `${DOCTOR_DIAGNOSTICS_DOCS_BASE}/${code}`;
+}
+
+function frameworkLabel(result: DoctorRunResult): string {
+  if (result.project.framework === "nuxt")
+    return `Nuxt ${result.project.nuxtVersion ?? "4"} + Vue ${result.project.vueVersion}`;
+  if (result.project.framework === "vite") return "Vite";
+  if (result.project.framework === "nitro") return "Nitro";
+  return `Vue ${result.project.vueVersion}`;
 }
 
 function sarifLevel(severity: Diagnostic["severity"]) {
@@ -278,32 +443,4 @@ function indent(value: string, prefix: string): string {
     .split("\n")
     .map((line) => `${prefix}${line}`)
     .join("\n");
-}
-
-function serializeDiagnostic(diagnostic: Diagnostic) {
-  return {
-    code: diagnostic.code,
-    name: diagnostic.diagnostic.name,
-    why: diagnostic.why,
-    fix: diagnostic.diagnostic.fix,
-    docs: diagnostic.docs,
-    sources: diagnostic.sources,
-    ruleId: diagnostic.ruleId,
-    severity: diagnostic.severity,
-    category: diagnostic.category,
-    file: diagnostic.file,
-    range: diagnostic.range,
-    suggestion: diagnostic.suggestion,
-    fixPlan: diagnostic.fix,
-    related: diagnostic.related,
-    tags: diagnostic.tags,
-    fingerprint: diagnostic.fingerprint,
-    suppressed: diagnostic.suppressed,
-    suppressionReason: diagnostic.suppressionReason,
-    confidence: diagnostic.confidence,
-    evidence: diagnostic.evidence,
-    fixGroupId: diagnostic.fixGroupId,
-    analysisPhase: diagnostic.analysisPhase,
-    cacheHit: diagnostic.cacheHit,
-  };
 }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -169,6 +169,13 @@ export async function createMigrationReport(
 
 export function formatMigrationReport(report: MigrationReport, format = "text"): string {
   if (format === "json") return `${JSON.stringify(report, null, 2)}\n`;
+  if (format === "agent") {
+    return `${JSON.stringify({
+      schema: "vite-doctor.migration/v1",
+      status: report.summary.diagnostics || report.summary.dependencyChanges ? "findings" : "clean",
+      ...report,
+    })}\n`;
+  }
   const lines = [
     `Migration target: ${report.target.requested.join(", ")} (${report.target.source})`,
     `Workspace: ${report.root}`,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,7 +17,7 @@ export interface ViteDoctorSurfaceOptions {
   severity?: "error" | "warn" | "info";
   maxWarnings?: number;
   cache?: boolean;
-  format?: "json" | "sarif";
+  format?: DoctorRunOptions["format"];
 }
 
 export function doctor(options: ViteDoctorSurfaceOptions = {}): Plugin {

--- a/src/rule-packs/nuxt/rules/vueuse.ts
+++ b/src/rule-packs/nuxt/rules/vueuse.ts
@@ -394,7 +394,10 @@ export const vueUseRulePack = defineRulePack({
   version: "0.0.0",
   activation: { nuxt: ">=4", packages: ["@vueuse/core"] },
   rules,
-  presets: { recommended: rules.map((rule) => rule.meta.id) },
+  presets: {
+    recommended: [noVueUseNuxtAutoImportCollision.meta.id],
+    strict: rules.map((rule) => rule.meta.id),
+  },
 });
 
 export default vueUseRulePack;

--- a/src/rule-packs/typescript/rules/index.ts
+++ b/src/rule-packs/typescript/rules/index.ts
@@ -17,16 +17,13 @@ import { noUnknownTypeAliases } from "./no-unknown-type-aliases.js";
 import { noUnvalidatedDeserialization } from "./no-unvalidated-deserialization.js";
 import { requireSafetyCommentForTypeAssertion } from "./require-safety-comment-for-type-assertion.js";
 
-const recommendedRules = [
-  noCallerChosenResultType,
-  noChainedTypeAssertions,
-  noObjectParameters,
-  noUnknownTypeAliases,
-  noUnvalidatedDeserialization,
-];
+const recommendedRules = [noChainedTypeAssertions, noUnvalidatedDeserialization];
 
 const strictRules = [
+  noCallerChosenResultType,
   ...recommendedRules,
+  noObjectParameters,
+  noUnknownTypeAliases,
   noConditionalEmptyObjectSpread,
   noRuntimeTypeof,
   requireSafetyCommentForTypeAssertion,

--- a/tests/core/agent-runtime.test.ts
+++ b/tests/core/agent-runtime.test.ts
@@ -1,0 +1,67 @@
+import { expect, test, vi } from "vite-plus/test";
+import { selectDoctorPresentation } from "../../src/core/internal/agent-runtime.ts";
+
+test("keeps an explicit report format in an agent runtime", async () => {
+  const determineAgent = vi.fn(async () => agent("codex_cli"));
+
+  await expect(
+    selectDoctorPresentation("sarif", { ci: true, tty: true, determineAgent }),
+  ).resolves.toEqual({ format: "sarif", automatic: false });
+  expect(determineAgent).not.toHaveBeenCalled();
+});
+
+test("selects agent output for every detected non-interactive coding agent", async () => {
+  for (const name of ["codex_cli", "claude_code", "gemini_cli", "custom-agent"]) {
+    await expect(
+      selectDoctorPresentation(undefined, {
+        ci: false,
+        tty: false,
+        determineAgent: async () => agent(name),
+      }),
+    ).resolves.toEqual({ format: "agent", detectedAgent: name, automatic: true });
+  }
+});
+
+test("does not select agent output in CI", async () => {
+  const determineAgent = vi.fn(async () => agent("codex_cli"));
+
+  await expect(
+    selectDoctorPresentation(undefined, { ci: true, tty: false, determineAgent }),
+  ).resolves.toEqual({ format: "text", automatic: false });
+  expect(determineAgent).not.toHaveBeenCalled();
+});
+
+test("does not select agent output in an interactive terminal", async () => {
+  const determineAgent = vi.fn(async () => agent("cursor"));
+
+  await expect(
+    selectDoctorPresentation(undefined, { ci: false, tty: true, determineAgent }),
+  ).resolves.toEqual({ format: "text", automatic: false });
+  expect(determineAgent).not.toHaveBeenCalled();
+});
+
+test("keeps text output when no agent is detected", async () => {
+  await expect(
+    selectDoctorPresentation(undefined, {
+      ci: false,
+      tty: false,
+      determineAgent: async () => ({ isAgent: false, agent: undefined }),
+    }),
+  ).resolves.toEqual({ format: "text", automatic: false });
+});
+
+test("fails open to text output when detection fails", async () => {
+  await expect(
+    selectDoctorPresentation(undefined, {
+      ci: false,
+      tty: false,
+      determineAgent: async () => {
+        throw new Error("detection failed");
+      },
+    }),
+  ).resolves.toEqual({ format: "text", automatic: false });
+});
+
+function agent(name: string) {
+  return { isAgent: true as const, agent: { name } };
+}

--- a/tests/core/plumbing.test.ts
+++ b/tests/core/plumbing.test.ts
@@ -1,11 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "pathe";
 import { expect, test } from "vite-plus/test";
 import {
   createJsonReport,
+  createAgentReport,
   createRulesReport,
   createSarifReport,
   createRule,
@@ -44,6 +45,72 @@ const reportProgramRule = createRule({
           }),
           {
             ruleId: "test/report-program",
+            severity: "warn",
+            category: "architecture",
+            file: ctx.file.path,
+            range: ctx.range(node),
+          },
+        );
+      },
+    };
+  },
+});
+
+const safeFixRule = createRule({
+  meta: {
+    id: "test/safe-fix",
+    title: "Safe fix",
+    category: "correctness",
+    severity: "error",
+    requires: { script: true },
+  },
+  create(ctx) {
+    return {
+      ScriptNode(node: any) {
+        if (node.type !== "Program") return;
+        const start = ctx.file.text.indexOf("bad");
+        if (start < 0) return;
+        ctx.report(
+          allDiagnostics.DOC9999({
+            why: "The fixture contains bad.",
+            fix: "Replace bad with good.",
+          }),
+          {
+            ruleId: "test/safe-fix",
+            severity: "error",
+            category: "correctness",
+            file: ctx.file.path,
+            range: ctx.range(node),
+            fix: {
+              kind: "safe",
+              edits: [{ range: { start, end: start + 3 }, text: "good" }],
+            },
+          },
+        );
+      },
+    };
+  },
+});
+
+const reportIdentifiersRule = createRule({
+  meta: {
+    id: "test/report-identifiers",
+    title: "Report identifiers",
+    category: "architecture",
+    severity: "warn",
+    requires: { script: true },
+  },
+  create(ctx) {
+    return {
+      ScriptNode(node: any) {
+        if (node.type !== "Identifier") return;
+        ctx.report(
+          allDiagnostics.DOC9999({
+            why: `Identifier ${node.name} was visited.`,
+            fix: "Inspect the test identifier diagnostic.",
+          }),
+          {
+            ruleId: "test/report-identifiers",
             severity: "warn",
             category: "architecture",
             file: ctx.file.path,
@@ -390,6 +457,44 @@ test("since scans no files when the requested Git diff is empty", async () => {
   });
 });
 
+test("changed scope reports diagnostics whose source ranges overlap changed lines", async () => {
+  await withFixture({ "src/app.ts": "const first = true\nconst second = true\n" }, async (root) => {
+    git(root, "init");
+    git(root, "add", ".");
+    git(
+      root,
+      "-c",
+      "user.name=Doctor",
+      "-c",
+      "user.email=doctor@example.com",
+      "commit",
+      "-m",
+      "fixture",
+    );
+    writeFileSync(join(root, "src/app.ts"), "const first = true\nconst second = false\n");
+
+    const result = await runDoctor({
+      root,
+      changed: true,
+      framework: "vue",
+      extensions: [pluginWith(reportIdentifiersRule, reportProgramRule, secondRule)],
+    });
+
+    expect(result.scope).toMatchObject({ mode: "changed", files: 1 });
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: "test/report-identifiers",
+          why: "Identifier second was visited.",
+          range: expect.objectContaining({ line: 2 }),
+        }),
+        expect.objectContaining({ ruleId: "test/report-program" }),
+      ]),
+    );
+  });
+});
+
 test("native rule glob matching filters enabled rules", async () => {
   await withFixture({ "src/app.ts": "const ok = true" }, async (root) => {
     const result = await runDoctor({
@@ -726,8 +831,55 @@ test("json reporter produces stable machine output", async () => {
     });
     const json = JSON.parse(createJsonReport(result));
 
-    expect(json.diagnostics[0].ruleId).toBe("test/report-program");
+    expect(json.diagnostics[0].rule).toBe("test/report-program");
+    expect(json.diagnostics[0].location.path).toBe("src/app.ts");
     expect(json.summary.warn).toBe(1);
+  });
+});
+
+test("agent reporter is compact and includes a complete remediation path", async () => {
+  await withFixture({ "src/app.ts": "const ok = true" }, async (root) => {
+    const result = await runDoctor({
+      root,
+      framework: "vue",
+      extensions: [pluginWith(reportProgramRule)],
+    });
+    const report = createAgentReport(result);
+    const agent = JSON.parse(report);
+
+    expect(agent.schema).toBe("vite-doctor.agent/v1");
+    expect(agent.diagnostics[0]).toMatchObject({
+      rule: "test/report-program",
+      location: { path: "src/app.ts" },
+      remediation: "Inspect the test program diagnostic.",
+    });
+    expect(agent.commands).toEqual({
+      explain: "vite-doctor explain <code> --format agent",
+      verify: "vite-doctor . --rules <rule> --format agent",
+      rerun: "vite-doctor . --format agent",
+    });
+    expect(report).not.toContain(join(root, "src/app.ts"));
+  });
+});
+
+test("safe fixes are rerun and the report contains only remaining diagnostics", async () => {
+  await withFixture({ "src/app.ts": "const bad = true\n" }, async (root) => {
+    const result = await runDoctor({
+      root,
+      framework: "vue",
+      fix: true,
+      cache: false,
+      baseline: "doctor-baseline.json",
+      updateBaseline: true,
+      extensions: [pluginWith(safeFixRule)],
+    });
+
+    expect(readFileSync(join(root, "src/app.ts"), "utf8")).toBe("const good = true\n");
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.fixes).toEqual({ files: 1, edits: 1, skipped: 0 });
+    expect(
+      JSON.parse(readFileSync(join(root, "doctor-baseline.json"), "utf8")).diagnostics,
+    ).toEqual([]);
   });
 });
 
@@ -784,7 +936,7 @@ test("sarif reporter includes partial fingerprints", async () => {
     });
     const sarif = JSON.parse(createSarifReport(result));
 
-    expect(sarif.runs[0].results[0].partialFingerprints["vue-doctor/v1"]).toBeTruthy();
+    expect(sarif.runs[0].results[0].partialFingerprints["vite-doctor/v1"]).toBeTruthy();
     expect(sarif.runs[0].results[0].ruleId).toBe("test/report-program");
   });
 });

--- a/tests/core/source-inventory.test.ts
+++ b/tests/core/source-inventory.test.ts
@@ -1,0 +1,246 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "pathe";
+import { expect, test } from "vite-plus/test";
+import type { ProjectInfo } from "../../src/core/primitives.ts";
+import {
+  GitChangeUnavailableError,
+  selectScanFiles,
+  selectSourceInventory,
+} from "../../src/core/internal/source-inventory.ts";
+import { parseGitChangeHunks } from "../../src/core/internal/git-change-ranges.ts";
+
+const vueProject: ProjectInfo = {
+  root: "",
+  framework: "vue",
+  ssr: false,
+  vueVersion: "3.5.0",
+  isMonorepo: false,
+};
+
+test("changed source inventory includes staged, unstaged, untracked, renamed, and deleted paths", async () => {
+  await withGitFixture(
+    {
+      "src/deleted.ts": "const deleted = true\n",
+      "src/old-name.ts": "const renamed = true\n",
+      "src/staged file.ts": "const first = true\nconst staged = false\nconst third = true\n",
+      "src/unstaged.ts": "const first = true\nconst second = true\nconst unstaged = false\n",
+      "src/unchanged.ts": "const unchanged = true\n",
+      "tests/ignored.test.ts": "const ignored = false\n",
+    },
+    async (root) => {
+      write(
+        root,
+        "src/staged file.ts",
+        "const first = true\nconst staged = true\nconst third = true\n",
+      );
+      git(root, "add", "src/staged file.ts");
+      write(
+        root,
+        "src/unstaged.ts",
+        "const first = true\nconst second = true\nconst unstaged = true\n",
+      );
+      write(root, "src/untracked.ts", "const one = true\nconst two = true\n");
+      write(root, "tests/ignored.test.ts", "const ignored = true\n");
+      git(root, "mv", "src/old-name.ts", "src/new-name.ts");
+      rmSync(join(root, "src/deleted.ts"));
+
+      const selection = await selectSourceInventory(
+        root,
+        {},
+        { changed: true },
+        { ...vueProject, root },
+      );
+
+      expect(selection.git?.status).toBe("available");
+      expect(selection.files.map((file) => file.displayPath)).toEqual([
+        "src/new-name.ts",
+        "src/staged file.ts",
+        "src/unstaged.ts",
+        "src/untracked.ts",
+      ]);
+      expect(
+        selection.files.map((file) => [file.displayPath, file.reportEligibility?.ranges]),
+      ).toEqual([
+        ["src/new-name.ts", []],
+        ["src/staged file.ts", [{ startLine: 2, endLine: 2 }]],
+        ["src/unstaged.ts", [{ startLine: 3, endLine: 3 }]],
+        ["src/untracked.ts", [{ startLine: 1, endLine: 2 }]],
+      ]);
+      if (selection.git?.status !== "available") throw new Error("Expected Git inventory.");
+      expect(selection.git.files).toContainEqual({
+        kind: "deleted",
+        previousPath: "src/deleted.ts",
+        hunks: [
+          {
+            previous: { startLine: 1, lineCount: 1 },
+            current: { startLine: 0, lineCount: 0 },
+          },
+        ],
+        reportRanges: [],
+      });
+      expect(selection.git.files).toContainEqual({
+        kind: "renamed",
+        previousPath: "src/old-name.ts",
+        path: "src/new-name.ts",
+        hunks: [],
+        reportRanges: [],
+      });
+    },
+  );
+});
+
+test("since compares HEAD and the worktree with the ref merge base", async () => {
+  await withGitFixture(
+    {
+      "src/app.ts": "const first = true\nconst feature = false\n",
+      "src/comparison.ts": "const comparison = false\n",
+    },
+    async (root) => {
+      const mergeBase = gitText(root, "rev-parse", "HEAD");
+      git(root, "branch", "comparison");
+      write(root, "src/app.ts", "const first = true\nconst feature = true\n");
+      git(root, "add", ".");
+      commit(root, "feature");
+
+      git(root, "checkout", "comparison");
+      write(root, "src/comparison.ts", "const comparison = true\n");
+      git(root, "add", ".");
+      commit(root, "comparison");
+      git(root, "checkout", "-");
+
+      const selection = await selectSourceInventory(
+        root,
+        {},
+        { since: "comparison" },
+        { ...vueProject, root },
+      );
+
+      expect(selection.git?.status).toBe("available");
+      if (selection.git?.status !== "available") throw new Error("Expected Git inventory.");
+      expect(selection.git.base).toBe(mergeBase);
+      expect(selection.files.map((file) => file.displayPath)).toEqual(["src/app.ts"]);
+      expect(selection.files[0]?.reportEligibility?.ranges).toEqual([{ startLine: 2, endLine: 2 }]);
+    },
+  );
+});
+
+test("changed source inventory treats every file as added before the first commit", async () => {
+  await withFixture({ "src/staged.ts": "const staged = true\n" }, async (root) => {
+    git(root, "init");
+    git(root, "add", "src/staged.ts");
+    write(root, "src/untracked.ts", "const untracked = true\n");
+
+    const selection = await selectSourceInventory(
+      root,
+      {},
+      { changed: true },
+      { ...vueProject, root },
+    );
+
+    expect(selection.git).toMatchObject({ status: "available", base: null });
+    expect(selection.files.map((file) => file.displayPath)).toEqual([
+      "src/staged.ts",
+      "src/untracked.ts",
+    ]);
+    expect(
+      selection.files.every((file) => file.reportEligibility?.ranges[0]?.startLine === 1),
+    ).toBe(true);
+  });
+});
+
+test("Git-unavailable scope is explicit and cannot look like a clean file selection", async () => {
+  await withFixture({ "src/app.ts": "const app = true\n" }, async (root) => {
+    const selection = await selectSourceInventory(
+      root,
+      {},
+      { changed: true },
+      { ...vueProject, root },
+    );
+
+    expect(selection).toMatchObject({
+      files: [],
+      git: { status: "unavailable", reason: "not-a-repository" },
+    });
+    await expect(
+      selectScanFiles(root, {}, { changed: true }, { ...vueProject, root }),
+    ).rejects.toBeInstanceOf(GitChangeUnavailableError);
+  });
+});
+
+test("an invalid since ref reports the ref and a stable reason", async () => {
+  await withGitFixture({ "src/app.ts": "const app = true\n" }, async (root) => {
+    const selection = await selectSourceInventory(
+      root,
+      {},
+      { since: "missing-branch" },
+      { ...vueProject, root },
+    );
+
+    expect(selection).toMatchObject({
+      files: [],
+      git: {
+        status: "unavailable",
+        reason: "invalid-ref",
+        ref: "missing-branch",
+      },
+    });
+  });
+});
+
+test("Git hunk parsing preserves deletion-only changes", () => {
+  expect(parseGitChangeHunks("@@ -4,2 +3,0 @@ const before = true\n-old\n-lines\n")).toEqual([
+    {
+      previous: { startLine: 4, lineCount: 2 },
+      current: { startLine: 3, lineCount: 0 },
+    },
+  ]);
+});
+
+async function withGitFixture(files: Record<string, string>, run: (root: string) => Promise<void>) {
+  await withFixture(files, async (root) => {
+    git(root, "init");
+    git(root, "add", ".");
+    commit(root, "fixture");
+    await run(root);
+  });
+}
+
+async function withFixture(files: Record<string, string>, run: (root: string) => Promise<void>) {
+  const root = await mkdtemp(join(tmpdir(), "vite-doctor-source-inventory-"));
+  try {
+    for (const [file, source] of Object.entries(files)) write(root, file, source);
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function write(root: string, file: string, source: string) {
+  const absolute = join(root, file);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, source);
+}
+
+function commit(root: string, message: string) {
+  git(
+    root,
+    "-c",
+    "user.name=Doctor",
+    "-c",
+    "user.email=doctor@example.com",
+    "commit",
+    "-m",
+    message,
+  );
+}
+
+function git(root: string, ...args: string[]) {
+  execFileSync("git", args, { cwd: root, stdio: "ignore" });
+}
+
+function gitText(root: string, ...args: string[]) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}

--- a/tests/rule-packs/nuxt/e2e-fixtures.test.ts
+++ b/tests/rule-packs/nuxt/e2e-fixtures.test.ts
@@ -80,8 +80,6 @@ test("Nuxt all-issues fixture reports Nuxt and ecosystem rule packs", async () =
     "nuxt/state/prefer-explicit-usestate-key-in-exported-composables:app/composables/useCounter.ts",
     "vue/template/html-button-has-type:app/pages/account.vue",
     "vueuse/no-nuxt-auto-import-collision:app/components/IssuePanel.vue",
-    "vueuse/prefer-use-storage:app/components/IssuePanel.vue",
-    "vueuse/prefer-usewindow-size:app/components/IssuePanel.vue",
   ]);
 });
 

--- a/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
+++ b/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
@@ -3304,9 +3304,7 @@ test("Nuxt Doctor rule payloads use JSON report helpers", () => {
     explainRule(nuxtRulePacks(), "nuxt/fetch/no-raw-fetch-in-setup", "json"),
   );
   expect(explanation.id).toBe("nuxt/fetch/no-raw-fetch-in-setup");
-  expect(JSON.parse(explainRule(nuxtRulePacks(), "nuxt/does-not-exist", "json"))).toEqual({
-    rule: null,
-  });
+  expect(explainRule(nuxtRulePacks(), "nuxt/does-not-exist", "json")).toBe("");
 });
 
 test("explicit Nuxt module sources are scanned with module metadata", async () => {

--- a/tests/rule-packs/typescript/typescript-rules.test.ts
+++ b/tests/rule-packs/typescript/typescript-rules.test.ts
@@ -16,7 +16,9 @@ import {
   typescriptRulePack,
 } from "../../../src/rule-packs/typescript/index.ts";
 
-const recommendedRules = [
+const recommendedRules = [noChainedTypeAssertions, noUnvalidatedDeserialization];
+
+const evidenceRules = [
   noCallerChosenResultType,
   noChainedTypeAssertions,
   noObjectParameters,
@@ -33,6 +35,9 @@ describe("TypeScript rule pack", () => {
     );
     expect(typescriptRulePack.presets.strict).toEqual(
       expect.arrayContaining([
+        "typescript/evidence/no-caller-chosen-result-type",
+        "typescript/evidence/no-object-parameters",
+        "typescript/evidence/no-unknown-type-aliases",
         "typescript/style/no-conditional-empty-object-spread",
         "typescript/strict/no-runtime-typeof",
         "typescript/strict/require-safety-comment-for-type-assertion",
@@ -43,7 +48,7 @@ describe("TypeScript rule pack", () => {
   test("reports missing type evidence and unvalidated boundaries", async () => {
     const result = await runProjectFixture({
       framework: "vite",
-      rules: recommendedRules,
+      rules: evidenceRules,
       files: {
         "src/index.ts": `function save(value: BroadObject) {}
 function parse<T>(text: string): T { return JSON.parse(text) }
@@ -70,7 +75,7 @@ console.log(save, parse, claimed, user)`,
   test("accepts concrete contracts and parsed runtime values", async () => {
     const result = await runProjectFixture({
       framework: "vite",
-      rules: recommendedRules,
+      rules: evidenceRules,
       files: {
         "src/index.ts": `interface SavedRecord { id: string }
 function save(value: SavedRecord) {}
@@ -313,14 +318,14 @@ if (typeof input === "string") console.log(options, input)
 
   test("activates recommended rules automatically for TypeScript only", async () => {
     const typescriptResult = await runBuiltinFixture({
-      "src/index.ts": "export function save(value: object) { return value }",
+      "src/index.ts": "export const user = input as object as User",
     });
     const javascriptResult = await runBuiltinFixture({
       "src/index.js": "export function save(value) { return value }",
     });
 
     expect(typescriptResult.diagnostics.map((item) => item.ruleId)).toContain(
-      "typescript/evidence/no-object-parameters",
+      "typescript/evidence/no-chained-type-assertions",
     );
     expect(javascriptResult.diagnostics.some((item) => item.ruleId.startsWith("typescript/"))).toBe(
       false,
@@ -331,11 +336,11 @@ if (typeof input === "string") console.log(options, input)
     "scans TypeScript .%s files after automatic activation",
     async (ext) => {
       const result = await runBuiltinFixture({
-        [`src/index.${ext}`]: "export function save(value: object) { return value }",
+        [`src/index.${ext}`]: "export const user = input as object as User",
       });
 
       expect(result.diagnostics.map((item) => item.ruleId)).toContain(
-        "typescript/evidence/no-object-parameters",
+        "typescript/evidence/no-chained-type-assertions",
       );
     },
   );
@@ -344,7 +349,7 @@ if (typeof input === "string") console.log(options, input)
     const result = await runBuiltinFixture(
       {
         "app.vue": `<script setup lang="ts">
-function save(value: object) { return value }
+const user = input as object as User
 </script>`,
       },
       undefined,
@@ -352,7 +357,7 @@ function save(value: object) { return value }
     );
 
     expect(result.diagnostics.map((item) => item.ruleId)).toContain(
-      "typescript/evidence/no-object-parameters",
+      "typescript/evidence/no-chained-type-assertions",
     );
   });
 

--- a/tests/vite/cli.test.ts
+++ b/tests/vite/cli.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/core/index.ts";
 import { expect, test } from "vite-plus/test";
 import { main } from "../../src/cli.ts";
+import { formatMigrationReport } from "../../src/migration.ts";
 import { doctor } from "../../src/plugin.ts";
 
 const publicPackageJson = JSON.parse(
@@ -27,7 +28,7 @@ test("package installs the TypeScript runtime required by its parsers", () => {
 
 test("CLI rejects removed run command", async () => {
   const repoRoot = findRepoRoot();
-  await expect(main(["run", "--dry-run"], repoRoot)).resolves.toBe(1);
+  await expect(main(["run", "--dry-run", "--format", "text"], repoRoot)).resolves.toBe(2);
 });
 
 test("CLI prints the public package version", async () => {
@@ -139,7 +140,7 @@ test("CLI accepts a path shorthand for scans", async () => {
         return true;
       }) as typeof process.stdout.write;
       try {
-        await expect(main(["."], root)).resolves.toBe(0);
+        await expect(main([".", "--format", "text"], root)).resolves.toBe(0);
       } finally {
         process.stdout.write = write;
       }
@@ -282,7 +283,7 @@ useRoute();
         [".", "--framework", "nuxt", "--rules", "nuxt/routing/prefer-nuxt-useroute"],
         root,
       );
-      expect(forced.code).toBe(1);
+      expect(forced.code).toBe(3);
       expect(forced.output).toContain("Detected: Nuxt");
       expect(forced.output).toContain("nuxt/routing/prefer-nuxt-useroute");
     },
@@ -311,34 +312,87 @@ const html = "<strong>unsafe</strong>";
   );
 });
 
-test("CLI rejects executable config loading in vite-doctor", async () => {
+test("CLI rejects the removed trusted config flag", async () => {
   await withFixture(
     {
       ...viteErrorFixture(),
       "doctor.config.ts": maliciousConfigSource("cli-trusted-marker"),
     },
     async (root) => {
-      const result = await main([".", "--trusted-config"], root);
-      expect(result).toBe(1);
+      const result = await main([".", "--trusted-config", "--format", "text"], root);
+      expect(result).toBe(2);
       expect(existsSync(join(root, "cli-trusted-marker"))).toBe(false);
     },
   );
 });
 
-test("CLI scan fails for a missing path", async () => {
-  const repoRoot = findRepoRoot();
-  const errors: string[] = [];
-  const error = console.error;
-  console.error = (...args: unknown[]) => {
-    errors.push(args.map(String).join(" "));
-  };
-  try {
-    await expect(main(["scan", "__missing_vite_doctor_path__"], repoRoot)).resolves.toBe(1);
-  } finally {
-    console.error = error;
-  }
+test("CLI automatically loads declarative Doctor config", async () => {
+  await withFixture(
+    {
+      ...viteErrorFixture(),
+      "doctor.config.json": JSON.stringify({
+        rules: { "vite/define/no-secret-define": "off" },
+      }),
+    },
+    async (root) => {
+      const result = await runCli(
+        [".", "--rules", "vite/define/no-secret-define", "--format", "json"],
+        root,
+      );
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.output).diagnostics).toEqual([]);
+    },
+  );
+});
 
-  expect(errors.join("\n")).toContain("No readable directory found");
+test("CLI explicitly loads executable Doctor config", async () => {
+  await withFixture(
+    {
+      ...viteErrorFixture(),
+      "doctor.config.ts": `import { writeFileSync } from "node:fs"
+writeFileSync(new URL("./explicit-config-loaded", import.meta.url), "yes")
+export default { rules: { "vite/define/no-secret-define": "off" } }
+`,
+    },
+    async (root) => {
+      const result = await runCli(
+        [
+          ".",
+          "--rules",
+          "vite/define/no-secret-define",
+          "--config",
+          "doctor.config.ts",
+          "--format",
+          "json",
+        ],
+        root,
+      );
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.output).diagnostics).toEqual([]);
+      expect(readFileSync(join(root, "explicit-config-loaded"), "utf8")).toBe("yes");
+    },
+  );
+});
+
+test("CLI returns structured failures for unknown Diagnostic Codes", async () => {
+  const result = await runWithCapturedStdout(() =>
+    main(["explain", "DOES_NOT_EXIST", "--format", "agent"], findRepoRoot()),
+  );
+  expect(result.code).toBe(2);
+  expect(JSON.parse(result.output)).toMatchObject({
+    schema: "vite-doctor.agent/v1",
+    status: "failed",
+    next: { action: "correct-invocation" },
+  });
+});
+
+test("CLI rejects the removed scan alias", async () => {
+  const repoRoot = findRepoRoot();
+  const result = await runWithCapturedStdout(() =>
+    main(["scan", "__missing_vite_doctor_path__", "--format=json"], repoRoot),
+  );
+  expect(result.code).toBe(2);
+  expect(JSON.parse(result.output).error.message).toContain("vite-doctor scan was removed");
 });
 
 test("exports a Vite plugin factory", () => {
@@ -583,7 +637,7 @@ export default defineHandler((event) => {
       expect(
         JSON.parse(result.output).diagnostics.find(
           (item: { code: string }) => item.code === "NITRO0014",
-        ).suggestion,
+        ).remediation,
       ).toBe('Import types from "nitro/types".');
       expect(codes).not.toContain("NITRO0008");
     },
@@ -620,6 +674,8 @@ test("unresolved runtime identity suppresses version-specific advice and reports
         (item: { code: string }) => item.code,
       );
 
+      expect(result.code).toBe(3);
+      expect(JSON.parse(result.output).status).toBe("incomplete");
       expect(codes.filter((code: string) => code === "DOC0022")).toHaveLength(1);
       expect(codes).not.toContain("NITRO0013");
       expect(codes).not.toContain("NITRO0014");
@@ -685,6 +741,11 @@ export default defineEventHandler((event) => {
           expect.objectContaining({ to: "future.compatibilityVersion: 5" }),
         ]),
       );
+      const agentResult = await runCli(["migrate", ".", "--format", "agent"], root);
+      expect(JSON.parse(agentResult.output)).toMatchObject({
+        schema: "vite-doctor.migration/v1",
+        status: "findings",
+      });
       const textResult = await runCli(["migrate", "."], root);
       expect(textResult.output).toContain(
         `Summary: ${report.summary.diagnostics} diagnostics, ${report.summary.dependencyChanges} dependency/config changes`,
@@ -718,6 +779,8 @@ export default defineNuxtConfig({
         instruction:
           "Verify that the effective future.compatibilityVersion resolves to 5; Doctor could not prove it from the composed Nuxt config.",
       });
+      expect(report.summary.errors).toBe(0);
+      expect(JSON.parse(formatMigrationReport(report, "agent")).status).toBe("findings");
     },
   );
 });
@@ -755,8 +818,11 @@ test("migrate rejects Nuxt targets outside Nuxt projects", async () => {
     async (root) => {
       const result = await runCli(["migrate", ".", "--to", "nuxt@5", "--format", "json"], root);
 
-      expect(result.code).toBe(1);
-      expect(result.output).toBe("");
+      expect(result.code).toBe(2);
+      expect(JSON.parse(result.output)).toMatchObject({
+        schema: "vite-doctor.report/v3",
+        status: "failed",
+      });
     },
   );
 });
@@ -769,8 +835,11 @@ test("migrate rejects Nitro targets outside Nuxt and Nitro projects", async () =
     async (root) => {
       const result = await runCli(["migrate", ".", "--to", "nitro@3", "--format", "json"], root);
 
-      expect(result.code).toBe(1);
-      expect(result.output).toBe("");
+      expect(result.code).toBe(2);
+      expect(JSON.parse(result.output)).toMatchObject({
+        schema: "vite-doctor.report/v3",
+        status: "failed",
+      });
     },
   );
 });
@@ -827,7 +896,10 @@ function withResolvedRuntimePackages(files: Record<string, string>): Record<stri
 }
 
 async function runCli(args: string[], root: string) {
-  return runWithCapturedStdout(() => main(args, root));
+  const explicitFormat = args.includes("--format");
+  return runWithCapturedStdout(() =>
+    main(explicitFormat ? args : [...args, "--format", "text"], root),
+  );
 }
 
 async function runWithCapturedStdout(fn: () => Promise<number>) {


### PR DESCRIPTION
## What changed

The default command is now `vite-doctor [path]`. This removes the `scan` and `check` aliases.

When Vercel's `detect-agent` recognizes a coding agent, every CLI command that returns a report uses compact JSON. An explicit `--format` still wins. Agent reports include relative file locations, the remediation, evidence, edit plans, docs links, and reusable commands to explain, verify, and rerun a Diagnostic.

`--changed` now reads staged, unstaged, and untracked changes against `HEAD`. `--since` uses the merge base of the requested ref. Doctor analyzes the whole file for context, then reports only Diagnostics whose ranges touch changed lines. Git errors stop the run instead of returning an empty report.

Fixes now run through the same policy and changed-line filters as the report. Doctor writes each edited file atomically, runs the checks again, and returns the Diagnostics that remain. Baselines update after that second run.

This also makes `doctor.config.json` the automatic, non-executable config. TypeScript config requires an explicit `--config` flag. JSON reports move to version 3 and drop repeated fields. The TypeScript and VueUse Recommended presets now keep the rules with concrete evidence; the preference rules remain available in Strict.

The npm package now includes the Doctor skill, updated for the changed-line and agent-report workflow.

## Breaking changes

- Replace `vite-doctor scan` and `vite-doctor check` with `vite-doctor [path]`.
- Update JSON consumers for report version 3 and the renamed Diagnostic fields.
- Treat exit code 2 as an invocation or config error. Exit code 3 means Doctor could not resolve required runtime evidence.
- Enable Strict if you relied on the TypeScript or VueUse preference rules from Recommended.

## Checks

- `pnpm check`
- `pnpm test`, 330 tests
- `pnpm build`
- `pnpm docs:build`, with the existing offline icon-fetch warnings

I packed the package with `pnpm pack`, installed that tarball in a clean directory, checked that the skill shipped, and ran the installed CLI against a real Vite project.

I also ran agent reports against these projects in `/tmp`. Doctor did not edit them.

| Project | Kind | Result |
| --- | --- | --- |
| Nuxt source | Nuxt | incomplete, 78 Diagnostics, 43.9 kB |
| Nitro source | Nitro | findings, 13 Diagnostics, 7.5 kB |
| Nuxt Color Mode | Nuxt module | incomplete, 3 Diagnostics, 3.1 kB |
| Babysitter | Vite and Vue | findings, 6 Diagnostics, 3.8 kB |
| Portal app | Nuxt app | findings, 132 Diagnostics, 72.1 kB |
