### PR TITLE
feat(nuxt): use native Doctor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,18 +144,12 @@ Use the Nuxt module surface for Nuxt-specific configuration:
 ```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
-  modules: [
-    [
-      "vite-doctor/nuxt",
-      {
-        config: {
-          rules: {
-            "nuxt/routing/prefer-nuxt-useroute": "error",
-          },
-        },
-      },
-    ],
-  ],
+  modules: ["vite-doctor/nuxt"],
+  doctor: {
+    rules: {
+      "nuxt/routing/prefer-nuxt-useroute": "error",
+    },
+  },
 });
 ```
 

--- a/docs/content/1.cli.md
+++ b/docs/content/1.cli.md
@@ -181,18 +181,12 @@ pnpm add -D vite-doctor
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
-  modules: [
-    [
-      "vite-doctor/nuxt",
-      {
-        config: {
-          rules: {
-            "nuxt/routing/prefer-nuxt-useroute": "error",
-          },
-        },
-      },
-    ],
-  ],
+  modules: ["vite-doctor/nuxt"],
+  doctor: {
+    rules: {
+      "nuxt/routing/prefer-nuxt-useroute": "error",
+    },
+  },
 });
 ```
 

--- a/docs/content/2.nuxt.md
+++ b/docs/content/2.nuxt.md
@@ -47,38 +47,30 @@ The migration report lists source changes that are safe on the installed runtime
 
 ## Configure
 
-Use module options for Nuxt projects. Host config is already trusted by Nuxt, so Doctor can receive in-memory surface configuration without loading a separate executable config file.
+Use the top-level `doctor` key for Nuxt projects. Host config is already trusted by Nuxt, so Doctor can receive in-memory surface configuration without loading a separate executable config file.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
-  modules: [
-    [
-      "vite-doctor/nuxt",
-      {
-        extends: "auto",
-        config: {
-          rules: {
-            "nuxt/routing/prefer-nuxt-useroute": "error",
-          },
-        },
-      },
-    ],
-  ],
+  modules: ["vite-doctor/nuxt"],
+  doctor: {
+    extends: "auto",
+    rules: {
+      "nuxt/routing/prefer-nuxt-useroute": "error",
+    },
+  },
 });
 ```
+
+Nuxt adds types for the `doctor` key when it prepares the project.
 
 Use `extends: "auto"` to keep Doctor's activated presets. Use an explicit array when you need to choose the Nuxt, Vue, and Nitro presets yourself:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
-  modules: [
-    [
-      "vite-doctor/nuxt",
-      {
-        extends: ["nuxt/recommended", "vue/recommended", "nitro/recommended"],
-      },
-    ],
-  ],
+  modules: ["vite-doctor/nuxt"],
+  doctor: {
+    extends: ["nuxt/recommended", "vue/recommended", "nitro/recommended"],
+  },
 });
 ```
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -25,7 +25,7 @@ const contentDumpRoutes = [
 export default defineNuxtConfig({
   extends: ["docus"],
 
-  modules: [["vite-doctor/nuxt"]],
+  modules: ["vite-doctor/nuxt"],
 
   css: ["~/assets/css/main.css"],
 

--- a/src/rule-packs/nuxt/module.ts
+++ b/src/rule-packs/nuxt/module.ts
@@ -1,4 +1,6 @@
 import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { defineNuxtModule } from "nuxt/kit";
+import type { NuxtModule } from "nuxt/schema";
 import { join, relative, resolve } from "pathe";
 import type {
   DoctorConfig,
@@ -9,11 +11,7 @@ import type {
 } from "../../core/index.js";
 export type { NuxtDoctorManifest } from "../../core/index.js";
 
-export interface NuxtDoctorModuleOptions {
-  config?: DoctorConfig;
-  extends?: "auto" | string[];
-  extensions?: DoctorExtension[];
-}
+export type NuxtDoctorModuleOptions = DoctorConfig;
 
 type EvidenceBuildManifest = {
   hasBuildManifest: boolean;
@@ -33,12 +31,9 @@ type NuxtDoctorEvidence = {
   autoImportContext?: NuxtAutoImportContext;
 };
 
-export default async function nuxtDoctorModule(options: NuxtDoctorModuleOptions = {}, nuxt: any) {
+async function setupNuxtDoctor(options: NuxtDoctorModuleOptions, nuxt: any) {
   nuxt.options ??= {};
-  nuxt.options.doctor ??= {};
-  nuxt.options.doctor.config ??= options.config;
-  nuxt.options.doctor.extends ??= options.extends;
-  nuxt.options.doctor.extensions ??= options.extensions;
+  nuxt.options.doctor = options;
 
   const evidence = {
     pages: [] as Array<{ path?: string; file?: string; name?: string }>,
@@ -97,6 +92,18 @@ export default async function nuxtDoctorModule(options: NuxtDoctorModuleOptions 
     await writeManifest(nuxt, evidence);
   });
 }
+
+const nuxtDoctorModule: NuxtModule<NuxtDoctorModuleOptions> = defineNuxtModule({
+  meta: {
+    name: "vite-doctor",
+    configKey: "doctor",
+    compatibility: { nuxt: ">=4" },
+    docs: "https://vite-doctor.onmax.me/nuxt",
+  },
+  setup: setupNuxtDoctor,
+});
+
+export default nuxtDoctorModule;
 
 export async function collectNuxtDoctorRulePacks(nuxt: any): Promise<RulePack[]> {
   const extraRulePacks: RulePack[] = [];
@@ -270,14 +277,7 @@ function normalizeModuleSource(source: NuxtModuleSource): NuxtModuleSource {
   };
 }
 
-function serializableDoctorConfig(
-  doctor: {
-    config?: DoctorConfig;
-    extends?: "auto" | string[];
-  } = {},
-): DoctorConfig | undefined {
-  const config = { ...doctor.config } as DoctorConfig;
-  config.extends ??= doctor.extends;
+function serializableDoctorConfig(config: DoctorConfig = {}): DoctorConfig | undefined {
   const payload: DoctorConfig = {};
   if (config.extends !== undefined) payload.extends = config.extends;
   if (config.include !== undefined) payload.include = config.include;

--- a/tests/fixtures/nuxt-all-issues/nuxt.config.ts
+++ b/tests/fixtures/nuxt-all-issues/nuxt.config.ts
@@ -1,5 +1,11 @@
 // @ts-nocheck
 export default defineNuxtConfig({
+  modules: ["../../../src/nuxt.ts"],
+  doctor: {
+    rules: {
+      "nuxt/imports/no-explicit-auto-import": "off",
+    },
+  },
   runtimeConfig: {
     public: {
       apiSecret: "public-secret",

--- a/tests/rule-packs/nuxt/e2e-fixtures.test.ts
+++ b/tests/rule-packs/nuxt/e2e-fixtures.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "vite-plus/test";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { relative } from "pathe";
-import { $fetch, setup } from "@nuxt/test-utils/e2e";
+import { join, relative } from "pathe";
+import { $fetch, setup, useTestContext } from "@nuxt/test-utils/e2e";
 import { defineDoctorExtension, runDoctor } from "../../../src/core/index.ts";
 import { vueRulePack } from "../../../src/rule-packs/vue/rules.ts";
 import { nuxtRulePacks } from "../../../src/rule-packs/nuxt/rules/index.ts";
@@ -92,6 +93,20 @@ describe("Nuxt all-issues fixture app", async () => {
   test("boots with Nuxt test utils", async () => {
     const html = await $fetch("/smoke");
     expect(html).toContain("Nuxt all issues fixture");
+  });
+
+  test("loads flat Doctor config through the Nuxt module", () => {
+    const buildDir = useTestContext().nuxt!.options.buildDir;
+    const manifest = JSON.parse(readFileSync(join(buildDir, "doctor.manifest.json"), "utf8"));
+    expect(manifest.doctorConfig).toEqual({
+      rules: {
+        "nuxt/imports/no-explicit-auto-import": "off",
+      },
+    });
+
+    const moduleTypes = readFileSync(join(buildDir, "types/modules.d.ts"), "utf8");
+    expect(moduleTypes).toContain('["doctor"]?:');
+    expect(moduleTypes).toContain("https://vite-doctor.onmax.me/nuxt");
   });
 });
 

--- a/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
+++ b/tests/rule-packs/nuxt/nuxt-modern-rules.test.ts
@@ -2945,10 +2945,20 @@ test("Nuxt module writes manifest and accepts context hook contributions", async
   });
 });
 
+test("Nuxt module exposes native Doctor config", async () => {
+  expect(await nuxtDoctorModule.getMeta?.()).toEqual({
+    name: "vite-doctor",
+    configKey: "doctor",
+    compatibility: { nuxt: ">=4" },
+    docs: "https://vite-doctor.onmax.me/nuxt",
+  });
+});
+
 test("Nuxt module records the resolved auto-import registry", async () => {
   await withFixture({}, {}, async (root) => {
     const hooks = new Map<string, Array<(payload: any) => unknown>>();
     const nuxt = {
+      _version: "4.5.1",
       options: {
         rootDir: root,
         srcDir: "app",
@@ -2966,7 +2976,7 @@ test("Nuxt module records the resolved auto-import registry", async () => {
       async callHook() {},
     };
 
-    await nuxtDoctorModule({}, nuxt);
+    await nuxtDoctorModule({}, nuxt as any);
     for (const hook of hooks.get("imports:context") ?? [])
       await hook({
         getImports: async () => [
@@ -3055,16 +3065,16 @@ useRoute();
     {},
     async (root) => {
       const nuxt = {
+        _version: "4.5.1",
         options: { rootDir: root, buildDir: ".nuxt", modules: [] },
+        async callHook() {},
       };
 
       await nuxtDoctorModule(
         {
-          config: {
-            rules: { "nuxt/routing/prefer-nuxt-useroute": "off" },
-          },
+          rules: { "nuxt/routing/prefer-nuxt-useroute": "off" },
         },
-        nuxt,
+        nuxt as any,
       );
       await writeManifest(nuxt);
 


### PR DESCRIPTION
`vite-doctor/nuxt` now uses Nuxt's native module contract, so projects register one module string and configure Doctor through a typed top-level `doctor` key. The generated editor docs link directly to Doctor's Nuxt guide.

This intentionally removes the nested `config` wrapper. Tuple options still work, but their fields are now the same flat `DoctorConfig` shape.

## Migration

```ts
// Before
modules: [["vite-doctor/nuxt", { config: { rules } }]]

// After
modules: ["vite-doctor/nuxt"]
doctor: { rules }
```

## Test plan

- `pnpm ready`
- `pnpm check`
- `pnpm docs:build`
- `pnpm test` with `dist` moved out of the checkout
- packed tarball in `nuxt-ui-templates/dashboard`: frozen install, prepare, generated types, Doctor behavior, lint, typecheck, and production build
- packed tarball in `nuxt/nuxt.com`: frozen install, prepare, generated types, Doctor behavior, typecheck, client build, and SSR build
