### PR TITLE
fix(nuxt): honor manifest preset selection

### DIFF
--- a/src/core/internal/scan-session.ts
+++ b/src/core/internal/scan-session.ts
@@ -139,7 +139,7 @@ export async function createScanSession(options: DoctorRunOptions): Promise<Scan
   const registry = await collectRulePacks(extensions);
   await applyProjectContributions(project, registry);
   const ruleConfigs = resolveRuleConfigs(config);
-  const enabledRules = selectRules(registry, ruleConfigs, options, project);
+  const enabledRules = selectRules(registry, ruleConfigs, options, config, project);
   markSession(sessionBase, "project", started);
 
   started = performance.now();
@@ -261,6 +261,7 @@ function selectRules(
   registry: RuleRegistry,
   ruleConfigs: Map<string, ResolvedRuleConfig>,
   options: DoctorRunOptions,
+  config: DoctorConfig,
   project: ProjectInfo,
 ): DoctorRule[] {
   const wanted = options.rules
@@ -268,7 +269,7 @@ function selectRules(
     .map((item) => item.trim())
     .filter(Boolean);
 
-  const selectedRules = resolveExtends(registry.packs, options, project);
+  const selectedRules = resolveExtends(registry.packs, options.extends ?? config.extends, project);
 
   const candidates = registry.rules
     .filter((rule) => selectedRules.has(rule.meta.id))
@@ -295,10 +296,9 @@ function selectRules(
 
 function resolveExtends(
   packs: RulePack[],
-  options: DoctorRunOptions,
+  requested: DoctorRunOptions["extends"] = "auto",
   project: ProjectInfo,
 ): Set<string> {
-  const requested = options.extends ?? options.config?.extends ?? "auto";
   if (requested === "auto") {
     return new Set(
       packs

--- a/tests/core/plumbing.test.ts
+++ b/tests/core/plumbing.test.ts
@@ -718,6 +718,44 @@ test("extends selection runs configured pack rules and config overrides extends"
   );
 });
 
+test("Nuxt manifest extends controls rule selection", async () => {
+  await withFixture(
+    {
+      "package.json": JSON.stringify({ dependencies: { nuxt: "^4.0.0" } }),
+      ".nuxt/doctor.manifest.json": JSON.stringify({
+        doctorConfig: { extends: ["test/strict"] },
+      }),
+      "app/app.ts": "const ok = true",
+    },
+    async (root) => {
+      const result = await runDoctor({
+        root,
+        cache: false,
+        extensions: [
+          defineDoctorExtension({
+            name: "test",
+            rulePacks: [
+              defineRulePack({
+                name: "test",
+                version: "0.0.0",
+                rules: [reportProgramRule, secondRule],
+                presets: {
+                  recommended: ["test/second-rule"],
+                  strict: ["test/report-program"],
+                },
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const ruleIds = result.diagnostics.map((item) => item.ruleId);
+      expect(ruleIds).toContain("test/report-program");
+      expect(ruleIds).not.toContain("test/second-rule");
+    },
+  );
+});
+
 test("defineRulePack requires a recommended preset", () => {
   let thrown: unknown;
   try {


### PR DESCRIPTION
Nuxt-native `doctor.extends` now controls Rule Pack preset selection after Doctor loads it from `.nuxt/doctor.manifest.json`. Explicit run options keep precedence over the merged Nuxt configuration.

## Validation

- `pnpm test tests/core/plumbing.test.ts`
- `pnpm check`
