### PR TITLE
feat: publish Doctor extension authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ export default defineNuxtConfig({
 });
 ```
 
+## Doctor extensions
+
+Library authors can import `createRule`, `defineRulePack`, `defineDoctorExtension`, and
+`defineDoctorDiagnostics` from `vite-doctor/extension`. The same entrypoint exports their
+authoring types.
+
 ## Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     ".": "./dist/index.mjs",
     "./cli": "./dist/cli.mjs",
     "./config": "./dist/config.mjs",
+    "./extension": "./dist/extension.mjs",
     "./nuxt": "./dist/nuxt.mjs",
     "./plugin": "./dist/plugin.mjs",
     "./rule-packs/nitro": "./dist/rule-packs/nitro/index.mjs",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -60,6 +60,7 @@ export async function loadDoctorConfig(options: LoadDoctorConfigOptions): Promis
     cwd: options.cwd,
     dotenv: false,
     globalRc: false,
+    extend: false,
     name: "doctor",
   });
   return defu(result.config ?? {}, options.defaults ?? {}) as DoctorConfig;

--- a/src/core/internal/scan-session.ts
+++ b/src/core/internal/scan-session.ts
@@ -220,15 +220,12 @@ async function collectRulePacks(extensions: DoctorExtension[]): Promise<{
       registerRulePack(pack) {
         registeredPacks.push(pack);
       },
-      registerReporter() {},
-      registerProjectDetector() {},
       registerProjectInventoryContributor(contributor) {
         inventoryContributors.push(contributor);
       },
       registerRuntimeEvidenceContributor(contributor) {
         runtimeEvidenceContributors.push(contributor);
       },
-      registerNuxtManifestContributor() {},
     });
   }
   const packs = [

--- a/src/core/primitives.ts
+++ b/src/core/primitives.ts
@@ -626,36 +626,17 @@ export interface DoctorRunResult {
   project: ProjectInfo;
 }
 
-export interface Reporter {
-  name: string;
-  write(result: DoctorRunResult): Promise<void> | void;
-}
-
 export interface DoctorExtension {
   name: string;
   version?: string;
   rulePacks?: RulePack[];
-  reporters?: Reporter[];
   setup?(api: DoctorExtensionApi): void | Promise<void>;
 }
 
 export interface DoctorExtensionApi {
   registerRulePack(pack: RulePack): void;
-  registerReporter(reporter: Reporter): void;
-  registerProjectDetector(detector: ProjectDetector): void;
   registerProjectInventoryContributor(contributor: ProjectInventoryContributor): void;
   registerRuntimeEvidenceContributor(contributor: RuntimeEvidenceContributor): void;
-  registerNuxtManifestContributor?(contributor: NuxtManifestContributor): void;
-}
-
-export interface ProjectDetector {
-  name: string;
-  detect(root: string): Promise<ProjectInfo | null>;
-}
-
-export interface NuxtManifestContributor {
-  name: string;
-  contribute(project: ProjectInfo): Promise<Record<string, unknown>> | Record<string, unknown>;
 }
 
 export interface ProjectInventoryContributor {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,21 @@
+export { createRule, defineDoctorExtension, defineRulePack } from "./core/primitives.js";
+export type {
+  DoctorExtension,
+  DoctorExtensionApi,
+  DoctorRule,
+  ProjectInventoryContributor,
+  RuleContext,
+  RuleMeta,
+  RulePack,
+  RuleVisitor,
+  RuntimeEvidenceContributor,
+  SourceFileHandle,
+  SourceRange,
+} from "./core/primitives.js";
+export { defineDoctorDiagnostics } from "./core/diagnostics.js";
+export type {
+  DoctorDiagnosticCodeEntry,
+  DoctorDiagnosticHandle,
+  DoctorDiagnosticParams,
+  DoctorDiagnosticRegistry,
+} from "./core/diagnostics.js";

--- a/tests/core/plumbing.test.ts
+++ b/tests/core/plumbing.test.ts
@@ -25,6 +25,7 @@ import {
   normalizeDiagnostic,
   normalizeDiagnosticFromRuleCode,
 } from "../../src/core/internal/diagnostics.ts";
+import { loadDoctorConfig } from "../../src/core/config.ts";
 import { scoreDiagnostics } from "../../src/core/internal/scoring.ts";
 import { getNodeVisitorKeys } from "../../src/core/internal/visitor-keys.ts";
 
@@ -1003,6 +1004,21 @@ test("rules and explain reports expose rule metadata as json", () => {
 
   expect(rules.rules[0].id).toBe("test/report-program");
   expect(explain.id).toBe("test/report-program");
+});
+
+test("executable config preserves Doctor preset selection without loading config layers", async () => {
+  for (const selection of [[], "auto", ["test/strict"]] as const) {
+    await withFixture(
+      { "doctor.config.mjs": `export default ${JSON.stringify({ extends: selection })}` },
+      async (root) => {
+        const config = await loadDoctorConfig({
+          cwd: root,
+          configFile: join(root, "doctor.config.mjs"),
+        });
+        expect(config.extends).toEqual(selection);
+      },
+    );
+  }
 });
 
 test("runDoctor does not load repository-local config by default", async () => {

--- a/tests/core/plumbing.test.ts
+++ b/tests/core/plumbing.test.ts
@@ -9,16 +9,18 @@ import {
   createAgentReport,
   createRulesReport,
   createSarifReport,
-  createRule,
   createNuxtProjectInventory,
   allDiagnostics,
   createDoctorDiagnosticsHost,
-  defineDoctorDiagnostics,
-  defineDoctorExtension,
-  defineRulePack,
   explainRule,
   runDoctor,
 } from "../../src/core/index.ts";
+import {
+  createRule,
+  defineDoctorDiagnostics,
+  defineDoctorExtension,
+  defineRulePack,
+} from "../../src/extension.ts";
 import {
   normalizeDiagnostic,
   normalizeDiagnosticFromRuleCode,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "src/index.ts",
     "src/cli.ts",
     "src/config.ts",
+    "src/extension.ts",
     "src/plugin.ts",
     "src/nuxt.ts",
     "src/rules.ts",


### PR DESCRIPTION
Doctor Extension authors can now import the supported authoring contract from `vite-doctor/extension`, including Rule, Rule Pack, diagnostic, inventory, and Runtime Evidence helpers and types. The extension interface no longer advertises reporter, project-detector, or Nuxt-manifest hooks that Doctor discarded during registration.

Executable Doctor configuration now preserves preset `extends` values. Disabling c12 config inheritance prevents it from recursively reloading the same explicit config while treating a Doctor preset as a config path.

## Validation

- Core plumbing and CLI tests, including absolute executable configs with `[]`, `auto`, and an explicit preset
- `pnpm build`
- `pnpm check`
- Isolated tarball install: imported all four authoring helpers, loaded an extension through explicit CLI config, emitted custom diagnostic `EXT0001`, and verified exit code 1
