### PR TITLE
fix(cli): remove unfinished type analysis

### DIFF
--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -142,7 +142,6 @@ function addDoctorRunCommand(
   cli
     .command("[path]", "Run Doctor diagnostics.")
     .option("--changed", "Report diagnostics on changed lines.")
-    .option("--types", "Enable type-aware rules.")
     .option(
       "--analyses <analyses>",
       "Comma-separated analyses: dead-code, graph, dupes, or health.",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -26,7 +26,6 @@ export interface DoctorRunOptions {
   newOnly?: boolean;
   severity?: "error" | "warn" | "info";
   rules?: string;
-  types?: boolean;
   coverage?: string;
   runtimeEvidence?: string;
   analyses?: string;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,13 +3,11 @@ import type { DoctorRunResult } from "./primitives.js";
 import { parseSourceFiles } from "./internal/facts.js";
 import {
   buildGraphPhase,
-  buildTypeGraphPhase,
   runDuplicationPhase,
   runFileRules,
   runGraphRules,
   runHealthPhase,
   runManifestRules,
-  runTypeRules,
 } from "./internal/rule-execution.js";
 import { cleanCache, createScanSession, markSession, runPhase } from "./internal/scan-session.js";
 import {
@@ -59,8 +57,6 @@ async function executeDoctorRun(options: DoctorRunOptions): Promise<DoctorRunRes
   await runPhase(session, "manifestRules", () => runManifestRules(session));
   await runPhase(session, "workspaceGraph", () => buildGraphPhase(session));
   await runPhase(session, "graphRules", () => runGraphRules(session));
-  await runPhase(session, "typeGraph", () => buildTypeGraphPhase(session));
-  await runPhase(session, "typeRules", () => runTypeRules(session));
   await runPhase(session, "duplication", () => runDuplicationPhase(session));
   await runPhase(session, "health", () => runHealthPhase(session));
   applyPolicyFilters(session);

--- a/src/core/internal/cli.ts
+++ b/src/core/internal/cli.ts
@@ -5,14 +5,12 @@ export function applyDoctorOptions(
   flags: Record<string, unknown>,
 ): void {
   if (flags.changed) options.changed = true;
-  if (flags.types) options.types = true;
   options.coverage = stringFlag(flags.coverage) ?? options.coverage;
   options.runtimeEvidence = stringFlag(flags.runtimeEvidence) ?? options.runtimeEvidence;
   options.analyses = stringFlag(flags.analyses) ?? options.analyses;
   if (flags.emitGraph) options.emitGraph = true;
   options.confidenceMin = stringFlag(flags.confidenceMin) ?? options.confidenceMin;
   if (flags.structuralReview) options.structuralReview = true;
-  if (flags.types === false) options.types = false;
   if (flags.profile) options.profile = true;
   if (flags.newOnly) options.newOnly = true;
   if (flags.updateBaseline) options.updateBaseline = true;

--- a/src/core/internal/diagnostics.ts
+++ b/src/core/internal/diagnostics.ts
@@ -338,7 +338,6 @@ export function reportRuntimeInventoryUnknown(session: ScanSession): void {
 
 export function defaultConfidenceForPhase(phase: Diagnostic["analysisPhase"]) {
   if (phase === "graph") return "proven";
-  if (phase === "type") return "type-backed";
   if (phase === "manifest") return "manifest-backed";
   if (phase === "duplication" || phase === "health") return "heuristic-high";
   return "heuristic-medium";
@@ -348,7 +347,6 @@ export function evidenceKindForPhase(phase: Diagnostic["analysisPhase"]) {
   if (phase === "file") return "ast";
   if (phase === "manifest") return "manifest";
   if (phase === "graph" || phase === "workspace") return "graph";
-  if (phase === "type") return "types";
   if (phase === "duplication" || phase === "health") return "facts";
   return "facts";
 }

--- a/src/core/internal/rule-execution.ts
+++ b/src/core/internal/rule-execution.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "pathe";
 import type { Diagnostic, DoctorRule, RuleContext, SourceFileHandle } from "../primitives.js";
-import type { DoctorRunOptions } from "../config.js";
 import { runVisitor } from "./rule-runner.js";
 import {
   buildWorkspaceGraph,
@@ -28,7 +27,7 @@ export async function runFileRules(session: ScanSession): Promise<void> {
   for (const rule of session.enabledRules) {
     if ((rule.meta.execution ?? "file") !== "file") continue;
     for (const file of session.handles) {
-      if (!canRunRuleOnFile(rule, file, session.options)) continue;
+      if (!canRunRuleOnFile(rule, file)) continue;
       const visitor = await rule.create(createRuleContext(session, file, rule));
       if (!visitor) continue;
       await runVisitor(visitor, file);
@@ -60,13 +59,6 @@ export async function runGraphRules(session: ScanSession): Promise<void> {
   if (!session.graph) return;
   runStructuralGraphRules(session, session.graph);
 }
-
-export async function buildTypeGraphPhase(session: ScanSession): Promise<void> {
-  if (!session.options.types) return;
-  session.timings.typeGraphStatus = 0;
-}
-
-export async function runTypeRules(_session: ScanSession): Promise<void> {}
 
 export async function runDuplicationPhase(session: ScanSession): Promise<void> {
   runDuplicationRules(session);
@@ -179,17 +171,12 @@ function createEmptySourceFileHandle(session: ScanSession): SourceFileHandle {
   };
 }
 
-function canRunRuleOnFile(
-  rule: DoctorRule,
-  file: SourceFileHandle,
-  options: DoctorRunOptions,
-): boolean {
+function canRunRuleOnFile(rule: DoctorRule, file: SourceFileHandle): boolean {
   if (rule.meta.sourceKinds && !rule.meta.sourceKinds.includes(file.sourceKind)) return false;
   const requires = rule.meta.requires;
   if (!requires) return true;
   if (requires.sfc && !file.sfc) return false;
   if (requires.template && !file.templateAst) return false;
   if (requires.script && !file.scriptAst) return false;
-  if (requires.types && !options.types) return false;
   return true;
 }

--- a/src/core/internal/scan-session.ts
+++ b/src/core/internal/scan-session.ts
@@ -281,7 +281,6 @@ function selectRules(
       (rule) =>
         !rule.meta.requires?.vue || project.framework === "vue" || project.framework === "nuxt",
     )
-    .filter((rule) => !rule.meta.requires?.types || options.types)
     .filter(
       (rule) => !wanted?.length || wanted.some((pattern) => nativeMatch(rule.meta.id, pattern)),
     )

--- a/src/core/primitives.ts
+++ b/src/core/primitives.ts
@@ -11,7 +11,6 @@ export interface DoctorSerializableConfig {
   exclude?: string[];
   rules?: Record<string, DoctorRuleConfig>;
   suppressions?: Array<{ ruleId?: string; fingerprint?: string; file?: string; reason: string }>;
-  typeAware?: boolean;
   cache?: { dir?: string; strategy?: "content-hash" };
   score?: { weights?: Partial<Record<"blocker" | "error" | "warn" | "info", number>> };
 }
@@ -20,22 +19,9 @@ export type DoctorFramework = "vue" | "nuxt" | "vite" | "nitro";
 export type ProjectLanguage = "typescript" | "javascript";
 export type RuntimePackageName = "nuxt" | "nitro" | "h3" | "vue";
 export type ApplicabilityState = "active" | "inactive" | "unknown";
-export type ExecutionKind =
-  | "file"
-  | "manifest"
-  | "workspace"
-  | "graph"
-  | "type"
-  | "duplication"
-  | "health";
+export type ExecutionKind = "file" | "manifest" | "workspace" | "graph" | "duplication" | "health";
 export type RuleCost = "tiny" | "small" | "medium" | "large" | "xlarge";
-export type CacheScope =
-  | "none"
-  | "file-text"
-  | "sfc-block"
-  | "workspace-graph"
-  | "type-project"
-  | "run";
+export type CacheScope = "none" | "file-text" | "sfc-block" | "workspace-graph" | "run";
 export type Determinism = "deterministic" | "env-dependent" | "runtime-dependent";
 export type EvidenceKind =
   | "facts"
@@ -120,7 +106,7 @@ export interface RuleMeta {
   docsUrl?: string;
   diagnosticCodes?: string[];
   version?: string;
-  requiresContext?: Array<"manifest" | "types" | "cross-file" | "template" | "script">;
+  requiresContext?: Array<"manifest" | "cross-file" | "template" | "script">;
   frameworkVersions?: {
     vue?: string;
     nuxt?: string;
@@ -135,7 +121,6 @@ export interface RuleMeta {
     sfc?: boolean;
     template?: boolean;
     script?: boolean;
-    types?: boolean;
     vue?: boolean;
     nitro?: boolean;
     nuxt?: boolean;
@@ -175,21 +160,6 @@ export interface SfcHandle {
   getTemplateTokens(): unknown;
   offsetToPosition(offset: number): SourceRange;
   blockOffsetToFileOffset(block: "template" | "script" | "scriptSetup", offset: number): number;
-}
-
-export interface TypeGraph {
-  programId: string;
-  projectRoots?: string[];
-  files?: string[];
-  resolveType(file: string, offset: number): unknown;
-  findSymbolRefs(file: string, offset: number): Array<{ file: string; range: SourceRange }>;
-  resolveExportTarget?(file: string, exportName: string): ResolvedSymbol | null;
-}
-
-export interface ResolvedSymbol {
-  file: string;
-  name: string;
-  range?: SourceRange;
 }
 
 export interface AutoImportEntry {
@@ -539,7 +509,6 @@ export interface RuleContext {
   project: ProjectInfo;
   file: SourceFileHandle;
   sfc?: SfcHandle;
-  types?: TypeGraph;
   severity: DoctorSeverity;
   options: unknown;
   report(diagnostic: NosticsDiagnostic, metadata: DoctorDiagnosticMetadata): void;

--- a/src/rule-packs/nuxt/module.ts
+++ b/src/rule-packs/nuxt/module.ts
@@ -284,7 +284,6 @@ function serializableDoctorConfig(config: DoctorConfig = {}): DoctorConfig | und
   if (config.exclude !== undefined) payload.exclude = config.exclude;
   if (config.rules !== undefined) payload.rules = config.rules;
   if (config.suppressions !== undefined) payload.suppressions = config.suppressions;
-  if (config.typeAware !== undefined) payload.typeAware = config.typeAware;
   if (config.cache !== undefined) payload.cache = config.cache;
   if (config.score !== undefined) payload.score = config.score;
   return Object.keys(payload).length ? payload : undefined;

--- a/tests/vite/cli.test.ts
+++ b/tests/vite/cli.test.ts
@@ -31,6 +31,16 @@ test("CLI rejects removed run command", async () => {
   await expect(main(["run", "--dry-run", "--format", "text"], repoRoot)).resolves.toBe(2);
 });
 
+test("CLI rejects the removed type analysis flag", async () => {
+  const result = await runCli([".", "--types", "--format", "agent"], findRepoRoot());
+
+  expect(result.code).toBe(2);
+  expect(JSON.parse(result.output)).toMatchObject({
+    error: { kind: "invocation" },
+    next: { action: "correct-invocation" },
+  });
+});
+
 test("CLI prints the public package version", async () => {
   const repoRoot = findRepoRoot();
   const writes: string[] = [];


### PR DESCRIPTION
Doctor no longer advertises type-aware analysis before a Type Graph exists. This removes `--types`, `typeAware`, and the unused Rule execution hooks; the TypeScript Rule Pack remains syntax-based as required by ADR 0012.

`--types` now returns the normal structured invocation error instead of running an unchanged Doctor Run.

## Validation

- `pnpm test` (335 tests)
- `pnpm build`
- `pnpm check`
- `node dist/cli.mjs --help`
- `node dist/cli.mjs . --types --format agent` (exit 2 with an invocation error)
