### PR TITLE
fix(docs): bundle prerendered icons

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -29,6 +29,18 @@ export default defineNuxtConfig({
 
   css: ["~/assets/css/main.css"],
 
+  icon: {
+    clientBundle: {
+      icons: [
+        "lucide:plug",
+        "lucide:plug-zap",
+        "lucide:wand-sparkles",
+        "vscode-icons:file-type-json",
+        "vscode-icons:file-type-nuxt",
+      ],
+    },
+  },
+
   runtimeConfig: {
     public: {
       doctorVersion: doctorPackage.version,

--- a/docs/package.json
+++ b/docs/package.json
@@ -42,6 +42,11 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:deploy",
+    "@iconify-json/logos": "catalog:frontend",
+    "@iconify-json/lucide": "catalog:frontend",
+    "@iconify-json/simple-icons": "catalog:frontend",
+    "@iconify-json/unjs": "catalog:frontend",
+    "@iconify-json/vscode-icons": "catalog:frontend",
     "esbuild": "catalog:build",
     "oxc-parser": "catalog:analysis",
     "wrangler": "catalog:deploy"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,21 @@ catalogs:
       specifier: ^4.118.0
       version: 4.118.0
   frontend:
+    '@iconify-json/logos':
+      specifier: ^1.2.13
+      version: 1.2.13
+    '@iconify-json/lucide':
+      specifier: ^1.2.121
+      version: 1.2.121
+    '@iconify-json/simple-icons':
+      specifier: ^1.2.93
+      version: 1.2.93
+    '@iconify-json/unjs':
+      specifier: ^1.2.4
+      version: 1.2.4
+    '@iconify-json/vscode-icons':
+      specifier: ^1.2.68
+      version: 1.2.68
     '@nuxt/fonts':
       specifier: ^0.14.0
       version: 0.14.0
@@ -364,6 +379,21 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^5.20260804.1
         version: 5.20260804.1
+      '@iconify-json/logos':
+        specifier: catalog:frontend
+        version: 1.2.13
+      '@iconify-json/lucide':
+        specifier: catalog:frontend
+        version: 1.2.121
+      '@iconify-json/simple-icons':
+        specifier: catalog:frontend
+        version: 1.2.93
+      '@iconify-json/unjs':
+        specifier: catalog:frontend
+        version: 1.2.4
+      '@iconify-json/vscode-icons':
+        specifier: catalog:frontend
+        version: 1.2.68
       esbuild:
         specifier: catalog:build
         version: 0.28.1
@@ -1414,11 +1444,17 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify-json/logos@1.2.13':
+    resolution: {integrity: sha512-Up54ZnIuiuBgGAsuzhR1nvKqwq8VE6YM3XLwVB6IgY+7NAasz6WKu9Ay5hGfAkfuOKowodfwDC8ozReEBYrWRg==}
+
   '@iconify-json/lucide@1.2.121':
     resolution: {integrity: sha512-zSoQQSmsyFaeTpSwURHJ9PIrsDcGFpDNhGlpiTrs+Ua4uFeH5UsE26L4OEBLrgLWoSK0UO+JhsO8yehSw0403g==}
 
   '@iconify-json/simple-icons@1.2.93':
     resolution: {integrity: sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==}
+
+  '@iconify-json/unjs@1.2.4':
+    resolution: {integrity: sha512-ueSrChjHps8u6jTSDYTAp+4OQ/k+E11PbKZQjKkDVnOxNpC+/fUXXkYgrnqEUgT0rSvUiS0B7X5A8GcsP/PjOA==}
 
   '@iconify-json/vscode-icons@1.2.68':
     resolution: {integrity: sha512-AG8aMOGv+dzQI50oOD9zMqvh/pnlhb8F2HR2FcKDN7qIZt4wFaUTxKAOtt49EskGdOl8z8Ll1vteUI060jCbDw==}
@@ -10553,11 +10589,19 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify-json/logos@1.2.13':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify-json/lucide@1.2.121':
     dependencies:
       '@iconify/types': 2.0.0
 
   '@iconify-json/simple-icons@1.2.93':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/unjs@1.2.4':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,11 @@ catalogs:
     agents: ^0.20.1
     wrangler: ^4.118.0
   frontend:
+    "@iconify-json/logos": ^1.2.13
+    "@iconify-json/lucide": ^1.2.121
+    "@iconify-json/simple-icons": ^1.2.93
+    "@iconify-json/unjs": ^1.2.4
+    "@iconify-json/vscode-icons": ^1.2.68
     "@nuxt/content": ^3.15.2
     "@nuxt/fonts": ^0.14.0
     "@nuxt/kit": ^4.5.1


### PR DESCRIPTION
The docs build now installs every Iconify collection used by the site and includes icons selected through runtime metadata or code-block filename lookup in Nuxt Icon's client bundle. Cloudflare prerender no longer emits repeated icon-load failures for the rendered pages.

## Test plan

- `pnpm install --frozen-lockfile --offline`
- `pnpm --dir docs check`
- `pnpm check`
- `pnpm docs:build` (599 routes, zero icon-load failures)
