### PR TITLE
fix: derive the rule catalog from Doctor extensions

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -9,19 +9,14 @@ import {
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "pathe";
 import { nitroRulePack } from "./rule-packs/nitro/index.js";
-import { nuxtDoctorExtensions, nuxtRulePacks } from "./rule-packs/nuxt/rules/index.js";
+import { nuxtDoctorExtensions } from "./rule-packs/nuxt/rules/index.js";
 import { vueRulePack } from "./rule-packs/vue/rules.js";
 import { viteRulePack } from "./rules.js";
 import { typescriptRulePack } from "./rule-packs/typescript/index.js";
 import { viteDoctorVersion } from "./version.js";
 
 export async function viteDoctorRulePacks(options: DoctorRunOptions = {}) {
-  const framework = detectRequestedFramework(options);
-  const packs = [viteRulePack, typescriptRulePack];
-  if (framework === "vue") packs.push(vueRulePack);
-  if (framework === "nitro") packs.push(nitroRulePack);
-  if (framework === "nuxt") packs.push(...nuxtRulePacks());
-  return packs.map(withDistributionVersion);
+  return (await viteDoctorExtensions(options)).flatMap((extension) => extension.rulePacks ?? []);
 }
 
 export async function viteDoctorExtensions(

--- a/tests/vite/cli.test.ts
+++ b/tests/vite/cli.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/core/index.ts";
 import { expect, test } from "vite-plus/test";
 import { main } from "../../src/cli.ts";
+import { viteDoctorExtensions, viteDoctorRulePacks } from "../../src/doctor.ts";
 import { formatMigrationReport } from "../../src/migration.ts";
 import { doctor } from "../../src/plugin.ts";
 
@@ -20,6 +21,68 @@ const publicPackageJson = JSON.parse(
   dependencies?: Record<string, string>;
 };
 const publicPackageVersion = publicPackageJson.version;
+
+test.each(["vite", "vue", "nitro", "nuxt"] as const)(
+  "builtin catalog matches ordered runtime Rule Packs for %s",
+  async (framework) => {
+    const packs = await viteDoctorRulePacks({ framework });
+    const extensions = await viteDoctorExtensions({ framework });
+
+    expect(packs).toEqual(extensions.flatMap((extension) => extension.rulePacks ?? []));
+    expect(new Set(packs.map((pack) => pack.name)).size).toBe(packs.length);
+    expect(packs.every((pack) => pack.version === publicPackageVersion)).toBe(true);
+  },
+);
+
+test.each(["auto", "explicit"])(
+  "Nuxt catalog lists and explains an emitted Vue diagnostic with %s framework selection",
+  async (selection) => {
+    await withFixture(
+      {
+        "package.json": JSON.stringify({ dependencies: { nuxt: "^4.0.0", vue: "^3.5.0" } }),
+        "app/app.vue": "<template><button>Save</button></template>",
+      },
+      async (root) => {
+        const frameworkOptions = selection === "explicit" ? ["--framework", "nuxt"] : [];
+        const ruleId = "vue/template/html-button-has-type";
+        const run = await runCli(
+          [".", "--rules", ruleId, "--no-cache", "--format", "json", ...frameworkOptions],
+          root,
+        );
+        expect(run.code).toBe(0);
+        const report = JSON.parse(run.output);
+        expect(report.framework).toBe("nuxt");
+        expect(report.diagnostics).toEqual([
+          expect.objectContaining({ code: "VUE0022", rule: ruleId }),
+        ]);
+
+        const catalog = await runCli(["rules", "--format", "json", ...frameworkOptions], root);
+        expect(catalog.code).toBe(0);
+        expect(
+          JSON.parse(catalog.output).rules.filter((rule: { id: string }) => rule.id === ruleId),
+        ).toEqual([
+          expect.objectContaining({
+            id: ruleId,
+            version: publicPackageVersion,
+            diagnosticCodes: ["VUE0022"],
+          }),
+        ]);
+
+        for (const diagnostic of ["VUE0022", ruleId]) {
+          const explanation = await runCli(
+            ["explain", diagnostic, "--format", "json", ...frameworkOptions],
+            root,
+          );
+          expect(explanation.code).toBe(0);
+          expect(JSON.parse(explanation.output)).toMatchObject({
+            id: ruleId,
+            diagnosticCodes: ["VUE0022"],
+          });
+        }
+      },
+    );
+  },
+);
 
 test("package installs the TypeScript runtime required by its parsers", () => {
   expect(publicPackageJson.dependencies?.["@typescript-eslint/parser"]).toBeTruthy();


### PR DESCRIPTION
Nuxt runs can emit Vue diagnostics that `rules` omits and `explain` cannot find. Build the built-in Rule Catalog from the same Doctor Extensions used by a run, so Vue is included once for Nuxt.

Keep framework selection, distribution versions, and runtime registration owned by the existing extensions.

[Before](https://github.com/onmax/vite-doctor/blob/8484de888fea7c9b8c57cbb8f3fa91ed117f5a10/src/doctor.ts#L18) · [After](https://github.com/onmax/vite-doctor/blob/bfe03a8ebcf99da93307486cdd791e66cbd75779/tests/vite/cli.test.ts#L38). The repository regression connects an emitted `VUE0022` diagnostic to listing and explanation under automatic and explicit Nuxt selection.
