### PR TITLE
refactor!: remove unsupported Doctor run options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ export default defineNuxtConfig({
 });
 ```
 
+### Removed run options
+
+Remove `coverage`, `runtimeEvidence`, `emitGraph`, `confidenceMin`, and `scoreOnly` from `DoctorRunOptions` objects. These options had no effect on Doctor Runs; their removal is a breaking TypeScript API change. Runtime Evidence contributors, graph reports, diagnostic confidence, and scoring remain supported.
+
 ## Doctor extensions
 
 Library authors can import `createRule`, `defineRulePack`, `defineDoctorExtension`, and

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -26,17 +26,12 @@ export interface DoctorRunOptions {
   newOnly?: boolean;
   severity?: "error" | "warn" | "info";
   rules?: string;
-  coverage?: string;
-  runtimeEvidence?: string;
   analyses?: string;
-  emitGraph?: boolean;
-  confidenceMin?: string;
   structuralReview?: boolean;
   profile?: boolean;
   cache?: boolean;
   fix?: boolean;
   unsafeFix?: boolean;
-  scoreOnly?: boolean;
   maxWarnings?: number;
   extensions?: DoctorExtension[];
   runtimeTarget?: RuntimeTarget;

--- a/src/core/internal/cli.ts
+++ b/src/core/internal/cli.ts
@@ -5,11 +5,7 @@ export function applyDoctorOptions(
   flags: Record<string, unknown>,
 ): void {
   if (flags.changed) options.changed = true;
-  options.coverage = stringFlag(flags.coverage) ?? options.coverage;
-  options.runtimeEvidence = stringFlag(flags.runtimeEvidence) ?? options.runtimeEvidence;
   options.analyses = stringFlag(flags.analyses) ?? options.analyses;
-  if (flags.emitGraph) options.emitGraph = true;
-  options.confidenceMin = stringFlag(flags.confidenceMin) ?? options.confidenceMin;
   if (flags.structuralReview) options.structuralReview = true;
   if (flags.profile) options.profile = true;
   if (flags.newOnly) options.newOnly = true;


### PR DESCRIPTION
`DoctorRunOptions` exposed five options that did not affect a run. Remove `coverage`, `runtimeEvidence`, `emitGraph`, `confidenceMin`, and `scoreOnly`, along with their dead forwarding assignments.

This intentionally removes unsupported TypeScript properties. Runtime Evidence contributors, report graphs, diagnostic confidence, scoring, and supported CLI behavior stay unchanged.

[Before](https://github.com/onmax/vite-doctor/blob/a3b8a591cf422d167b8a5fc1b9596c87515f63ee/src/core/config.ts#L29) · [After](https://github.com/onmax/vite-doctor/blob/84bd61b459891933106f53209197c9a01bdab975/README.md#L156).
