### PR TITLE
fix: keep inline suppressions within their target lines

### DIFF
--- a/src/core/internal/diagnostic-policy.ts
+++ b/src/core/internal/diagnostic-policy.ts
@@ -17,10 +17,11 @@ export interface DiagnosticPolicyResult {
 
 export function applyDiagnosticPolicy(input: DiagnosticPolicyInput): DiagnosticPolicyResult {
   const suppressed: Diagnostic[] = [];
+  const sourceLines = new Map<string, string[]>();
   const baseline = readBaseline(input.root, input.options.baseline);
   const nextDiagnostics: Diagnostic[] = [];
   for (const diagnostic of input.diagnostics) {
-    const suppression = findSuppression(input.root, input.config, diagnostic);
+    const suppression = findSuppression(input.root, input.config, diagnostic, sourceLines);
     const inBaseline = baseline.has(diagnostic.fingerprint ?? "");
     if (suppression || (input.options.newOnly && inBaseline)) {
       suppressed.push({
@@ -98,6 +99,7 @@ function findSuppression(
   root: string,
   config: DoctorConfig,
   diagnostic: Diagnostic,
+  sourceLines: Map<string, string[]>,
 ): string | null {
   const configured = config.suppressions?.find((suppression) => {
     if (suppression.ruleId && suppression.ruleId !== diagnostic.ruleId) return false;
@@ -107,16 +109,29 @@ function findSuppression(
     return true;
   });
   if (configured) return configured.reason;
-  const text = readFileSync(diagnostic.file, "utf8");
+  let lines = sourceLines.get(diagnostic.file);
+  if (!lines) {
+    try {
+      lines = readFileSync(diagnostic.file, "utf8").split(/\r?\n/);
+    } catch {
+      lines = [];
+    }
+    sourceLines.set(diagnostic.file, lines);
+  }
   const line = diagnostic.range?.line;
-  const lines = text.split(/\r?\n/);
-  const nearby = line ? lines.slice(Math.max(0, line - 3), line + 1).join("\n") : text;
-  const inline = nearby.match(/doctor-disable(?:-next-line)?\s+([^\s]+)(?:\s+--\s+(.+)|\s+(.+))?/);
-  if (!inline) return null;
-  const rules = inline[1].split(",").map((item) => item.trim());
-  if (!rules.includes(diagnostic.ruleId) && !rules.includes("*")) return null;
-  const reason = (inline[2] ?? inline[3] ?? "").trim();
-  return reason || "missing suppression reason";
+  const start = line ? Math.max(0, line - 3) : 0;
+  const end = line ? Math.min(lines.length, line + 1) : lines.length;
+  for (let index = start; index < end; index++) {
+    const inline = lines[index]!.match(
+      /doctor-disable(-next-line)?\s+([^\s]+)(?:\s+--\s+(.+)|\s+(.+))?/,
+    );
+    if (!inline || (inline[1] && line !== index + 2)) continue;
+    const rules = inline[2]!.split(",").map((item) => item.trim());
+    if (!rules.includes(diagnostic.ruleId) && !rules.includes("*")) continue;
+    const reason = (inline[3] ?? inline[4] ?? "").trim();
+    return reason || "missing suppression reason";
+  }
+  return null;
 }
 
 function nativeMatch(value: string, pattern: string): boolean {

--- a/tests/core/diagnostic-policy.test.ts
+++ b/tests/core/diagnostic-policy.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
+import { afterEach, expect, test } from "vite-plus/test";
+import { applyDiagnosticPolicy } from "../../src/core/internal/diagnostic-policy.ts";
+import { normalizeDiagnosticFromRuleCode } from "../../src/core/internal/diagnostics.ts";
+
+const roots: string[] = [];
+
+function fixture(text?: string) {
+  const root = mkdtempSync(join(tmpdir(), "doctor-policy-"));
+  roots.push(root);
+  const file = join(root, "app.ts");
+  if (text !== undefined) writeFileSync(file, text);
+  return { root, file };
+}
+
+function finding(file: string, line?: number) {
+  return normalizeDiagnosticFromRuleCode({
+    code: "DOC9999",
+    ruleId: "test/example",
+    severity: "warn",
+    category: "correctness",
+    why: "Fixture diagnostic.",
+    suggestion: "Fix the fixture.",
+    file,
+    range: line === undefined ? undefined : { start: 0, end: 1, line, column: 1 },
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test.each([1, 2, 4])("next-line suppression does not hide a diagnostic on line %i", (line) => {
+  const { root, file } = fixture(
+    [
+      "const before = 1;",
+      "// doctor-disable-next-line test/example -- intentional fixture",
+      "const ignored = 2;",
+      "const after = 3;",
+    ].join("\n"),
+  );
+  const diagnostic = finding(file, line);
+  const result = applyDiagnosticPolicy({
+    root,
+    config: {},
+    options: {},
+    diagnostics: [diagnostic],
+  });
+  expect(result.diagnostics).toEqual([diagnostic]);
+  expect(result.suppressedDiagnostics).toEqual([]);
+});
+
+test.each(["\n", "\r\n"])("next-line suppression applies to its target line with %j", (newline) => {
+  const { root, file } = fixture(
+    ["// doctor-disable-next-line test/example -- intentional fixture", "const ignored = 2;"].join(
+      newline,
+    ),
+  );
+  const result = applyDiagnosticPolicy({
+    root,
+    config: {},
+    options: {},
+    diagnostics: [finding(file, 2)],
+  });
+  expect(result.diagnostics).toEqual([]);
+  expect(result.suppressedDiagnostics).toMatchObject([
+    { suppressionReason: "intentional fixture" },
+  ]);
+});
+
+test("an unrelated directive does not mask the next-line suppression for this rule", () => {
+  const { root, file } = fixture(
+    [
+      "// doctor-disable-next-line test/unrelated -- another diagnostic",
+      "// doctor-disable-next-line test/example -- intentional fixture",
+      "const ignored = 2;",
+    ].join("\n"),
+  );
+  const result = applyDiagnosticPolicy({
+    root,
+    config: {},
+    options: {},
+    diagnostics: [finding(file, 3)],
+  });
+  expect(result.diagnostics).toEqual([]);
+  expect(result.suppressedDiagnostics).toMatchObject([
+    { suppressionReason: "intentional fixture" },
+  ]);
+});
+
+test("next-line suppression does not hide a diagnostic without a source range", () => {
+  const { root, file } = fixture(
+    "// doctor-disable-next-line * -- intentional fixture\nconst ignored = 2;",
+  );
+  const diagnostic = finding(file);
+  const result = applyDiagnosticPolicy({
+    root,
+    config: {},
+    options: {},
+    diagnostics: [diagnostic],
+  });
+  expect(result.diagnostics).toEqual([diagnostic]);
+});
+
+test("diagnostics for missing source files remain reportable", () => {
+  const { root, file } = fixture();
+  const diagnostic = finding(file);
+  const result = applyDiagnosticPolicy({
+    root,
+    config: {},
+    options: {},
+    diagnostics: [diagnostic],
+  });
+  expect(result.diagnostics).toEqual([diagnostic]);
+});
+
+test("configured suppressions still apply to missing source files", () => {
+  const { root, file } = fixture();
+  const result = applyDiagnosticPolicy({
+    root,
+    config: { suppressions: [{ ruleId: "test/example", reason: "generated source" }] },
+    options: {},
+    diagnostics: [finding(file)],
+  });
+  expect(result.diagnostics).toEqual([]);
+  expect(result.suppressedDiagnostics).toMatchObject([{ suppressionReason: "generated source" }]);
+});
+
+test("plain inline suppressions still apply to nearby diagnostics", () => {
+  const { root, file } = fixture(
+    "const ignored = 2; // doctor-disable test/example -- intentional fixture",
+  );
+  const result = applyDiagnosticPolicy({
+    root,
+    config: {},
+    options: {},
+    diagnostics: [finding(file, 1)],
+  });
+  expect(result.diagnostics).toEqual([]);
+  expect(result.suppressedDiagnostics).toMatchObject([
+    { suppressionReason: "intentional fixture" },
+  ]);
+});
+
+test("a suppression without a reason does not consume the next source line as its reason", () => {
+  const { root, file } = fixture("// doctor-disable-next-line test/example\nconst ignored = 2;");
+  const result = applyDiagnosticPolicy({
+    root,
+    config: {},
+    options: {},
+    diagnostics: [finding(file, 2)],
+  });
+  expect(result.suppressedDiagnostics).toMatchObject([
+    { suppressionReason: "missing suppression reason" },
+  ]);
+});
+
+test("removing a suppression is reflected in the next Doctor policy pass", () => {
+  const { root, file } = fixture(
+    "// doctor-disable-next-line test/example -- intentional fixture\nconst ignored = 2;",
+  );
+  const diagnostic = finding(file, 2);
+  const input = { root, config: {}, options: {}, diagnostics: [diagnostic] };
+  expect(applyDiagnosticPolicy(input).suppressedDiagnostics).toHaveLength(1);
+  writeFileSync(file, "// suppression removed\nconst ignored = 2;");
+  expect(applyDiagnosticPolicy(input).diagnostics).toEqual([diagnostic]);
+});


### PR DESCRIPTION
`doctor-disable-next-line` could suppress findings before, on, and after its intended target line. An earlier unrelated directive could also block a valid suppression, and a finding whose source file no longer existed could abort the Doctor Run.

Restrict next-line directives to their target, continue past unrelated directives, and keep missing-source findings reportable. Source text is read once per file within each policy pass; edits remain visible on the next pass.

Validation: six regression cases failed before the fix; all 12 new regression tests and all 70 core tests pass. Scoped lint and the package/declaration build pass.
