### PR TITLE
fix: make changed-line inventory independent of Git display settings

### DIFF
--- a/src/core/internal/git-change-ranges.ts
+++ b/src/core/internal/git-change-ranges.ts
@@ -150,7 +150,9 @@ export async function collectGitChangeInventory(
   }
 
   for (const path of untracked.paths.filter(includePath)) {
-    const lineCount = currentLineCount(resolve(root, path));
+    const absolute = resolve(root, path);
+    if (!statSync(absolute, { throwIfNoEntry: false })?.isFile()) continue;
+    const lineCount = currentLineCount(absolute);
     changes.push({
       kind: "untracked",
       path,
@@ -263,8 +265,10 @@ async function collectFileHunks(
   const result = await runGit(root, [
     "diff",
     "--unified=0",
+    "--inter-hunk-context=0",
     "--no-color",
     "--no-ext-diff",
+    "--no-textconv",
     base,
     "--",
     ...(previousPath ? [previousPath] : []),

--- a/tests/core/source-inventory.test.ts
+++ b/tests/core/source-inventory.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "pathe";
@@ -19,6 +19,61 @@ const vueProject: ProjectInfo = {
   vueVersion: "3.5.0",
   isMonorepo: false,
 };
+
+test("changed line ranges ignore Git inter-hunk context configuration", async () => {
+  await withGitFixture(
+    { "src/app.ts": "const first = false\nconst unchanged = true\nconst last = false\n" },
+    async (root) => {
+      git(root, "config", "diff.interHunkContext", "10");
+      write(root, "src/app.ts", "const first = true\nconst unchanged = true\nconst last = true\n");
+      const selection = await selectSourceInventory(
+        root,
+        {},
+        { changed: true },
+        { ...vueProject, root },
+      );
+      expect(selection.files[0]?.reportEligibility?.ranges).toEqual([
+        { startLine: 1, endLine: 1 },
+        { startLine: 3, endLine: 3 },
+      ]);
+    },
+  );
+});
+
+test("changed line ranges use source text instead of Git text conversion drivers", async () => {
+  await withGitFixture(
+    { ".gitattributes": "*.ts diff=doctor-test\n", "src/app.ts": "const changed = false\n" },
+    async (root) => {
+      git(root, "config", "diff.doctor-test.textconv", "printf converted");
+      write(root, "src/app.ts", "const changed = true\n");
+      const selection = await selectSourceInventory(
+        root,
+        {},
+        { changed: true },
+        { ...vueProject, root },
+      );
+      expect(selection.files[0]?.reportEligibility?.ranges).toEqual([{ startLine: 1, endLine: 1 }]);
+    },
+  );
+});
+
+test.skipIf(process.platform === "win32")(
+  "changed source inventory skips dangling untracked symlinks",
+  async () => {
+    await withGitFixture({ "src/app.ts": "const app = true\n" }, async (root) => {
+      symlinkSync("missing.ts", join(root, "src/dangling.ts"));
+      write(root, "src/new.ts", "const added = true\n");
+      const selection = await selectSourceInventory(
+        root,
+        {},
+        { changed: true },
+        { ...vueProject, root },
+      );
+      expect(selection.git?.status).toBe("available");
+      expect(selection.files.map((file) => file.displayPath)).toEqual(["src/new.ts"]);
+    });
+  },
+);
 
 test("changed source inventory includes staged, unstaged, untracked, renamed, and deleted paths", async () => {
   await withGitFixture(


### PR DESCRIPTION
Doctor's changed-line selection inherited Git display settings. `diff.interHunkContext` could include unchanged lines, and a text conversion driver could erase the changed ranges entirely. An untracked dangling source symlink also crashed inventory collection with `ENOENT`.

Request zero inter-hunk context and raw source diffs, and skip untracked paths that do not resolve to regular files, matching the existing unborn-repository handling.

Validation: all three new regression tests failed before the fix. Source inventory and core plumbing now pass all 43 tests; scoped lint and formatting pass. The symlink regression runs on Unix and skips Windows, where creating symlinks requires additional privileges.
