### PR TITLE
perf: skip AST traversal for unused visitor hooks

### DIFF
--- a/src/core/internal/rule-runner.ts
+++ b/src/core/internal/rule-runner.ts
@@ -3,12 +3,13 @@ import { getNodeVisitorKeys, getTemplateVisitorKeys } from "./visitor-keys.js";
 
 export async function runVisitor(visitor: RuleVisitor, file: SourceFileHandle) {
   if (file.sfc) await visitor.SFC?.(file.sfc);
-  if (file.scriptAst)
+  if (file.scriptAst && (visitor.ScriptNode || visitor.ImportDeclaration))
     walkScript(file.scriptAst, (node) => {
       visitor.ScriptNode?.(node);
       if ((node as any).type === "ImportDeclaration") visitor.ImportDeclaration?.(node);
     });
-  if (file.templateAst) walkTemplate(file.templateAst, (node) => visitor.TemplateNode?.(node));
+  if (file.templateAst && visitor.TemplateNode)
+    walkTemplate(file.templateAst, (node) => visitor.TemplateNode?.(node));
 }
 
 function walkScript(node: unknown, visit: (node: unknown) => void, parent?: unknown) {

--- a/tests/core/rule-runner.bench.ts
+++ b/tests/core/rule-runner.bench.ts
@@ -1,0 +1,45 @@
+import { beforeAll, bench } from "vite-plus/test";
+import { createRule, type SourceFileHandle } from "../../src/core/primitives.ts";
+import { runProjectFixture } from "../../src/core/testkit.ts";
+import { runVisitor } from "../../src/core/internal/rule-runner.ts";
+
+let file: SourceFileHandle;
+
+beforeAll(async () => {
+  const declarations = Array.from({ length: 200 }, (_, index) => `const value${index} = ${index}`);
+  const elements = Array.from({ length: 200 }, (_, index) => `<span>{{ value${index} }}</span>`);
+  await runProjectFixture({
+    files: {
+      "app.vue": `<script setup>\n${declarations.join("\n")}\n</script>
+<template><div>${elements.join("\n")}</div></template>`,
+    },
+    rules: [
+      createRule({
+        meta: {
+          id: "test/capture-file",
+          title: "Capture benchmark file",
+          category: "performance",
+          severity: "info",
+        },
+        create(ctx) {
+          file = ctx.file;
+        },
+      }),
+    ],
+  });
+  if (!file.scriptAst || !file.templateAst || !file.sfc) {
+    throw new Error("The benchmark requires parsed script, template, and SFC handles");
+  }
+});
+
+bench("SFC visitor on a 200-binding component", async () => {
+  await runVisitor({ SFC() {} }, file);
+});
+
+bench("script visitor on a 200-binding component", async () => {
+  await runVisitor({ ScriptNode() {} }, file);
+});
+
+bench("template visitor on a 200-binding component", async () => {
+  await runVisitor({ TemplateNode() {} }, file);
+});

--- a/tests/core/rule-runner.test.ts
+++ b/tests/core/rule-runner.test.ts
@@ -1,0 +1,107 @@
+import { expect, test, vi } from "vite-plus/test";
+import type { RuleVisitor, SourceFileHandle } from "../../src/core/primitives.ts";
+import { runVisitor } from "../../src/core/internal/rule-runner.ts";
+import { parseSfcFile } from "../../src/core/internal/sfc.ts";
+import { parseScript } from "../../src/core/internal/script.ts";
+
+function createFile(): SourceFileHandle {
+  return {
+    path: "/app.vue",
+    relativePath: "app.vue",
+    sourceKind: "app",
+    text: "",
+    hash: "fixture",
+    isVueSfc: true,
+    scriptAst: { type: "Program", body: [] },
+    templateAst: { type: "VDocumentFragment", children: [] },
+    project: {
+      root: "/",
+      framework: "vue",
+      ssr: false,
+      vueVersion: "3.5.0",
+      isMonorepo: false,
+    },
+    matches: () => true,
+    inAppDir: () => false,
+    isModuleSource: () => false,
+  };
+}
+
+test.each<keyof RuleVisitor>(["SFC", "onProjectStart", "TemplateNode"])(
+  "%s visitors do not traverse the script AST",
+  async (hook) => {
+    const file = createFile();
+    file.sfc = await parseSfcFile(file.path, "<template><div /></template>");
+    const body = vi.fn(() => []);
+    Object.defineProperty(file.scriptAst, "body", { get: body, enumerable: true });
+    const callback = vi.fn();
+
+    await runVisitor({ [hook]: callback }, file);
+
+    expect(body).not.toHaveBeenCalled();
+    if (hook !== "onProjectStart") expect(callback).toHaveBeenCalledOnce();
+  },
+);
+
+test.each<keyof RuleVisitor>(["SFC", "onProjectStart", "ScriptNode", "ImportDeclaration"])(
+  "%s visitors do not traverse the template AST",
+  async (hook) => {
+    const file = createFile();
+    const children = vi.fn(() => []);
+    Object.defineProperty(file.templateAst, "children", { get: children, enumerable: true });
+
+    await runVisitor({ [hook]: vi.fn() }, file);
+
+    expect(children).not.toHaveBeenCalled();
+  },
+);
+
+test("import-only visitors receive imports with script parent links", async () => {
+  const file = createFile();
+  file.scriptAst = parseScript("app.ts", 'import { ref } from "vue"; const count = ref(0)');
+  const imports: unknown[] = [];
+
+  await runVisitor({ ImportDeclaration: (node) => imports.push(node) }, file);
+
+  expect(imports).toHaveLength(1);
+  expect(imports[0]).toMatchObject({ type: "ImportDeclaration", source: { value: "vue" } });
+  expect(Object.getOwnPropertyDescriptor(imports[0], "__doctorParent")).toMatchObject({
+    value: file.scriptAst,
+    enumerable: false,
+  });
+});
+
+test("awaits SFC hooks before dispatching script and template visitors", async () => {
+  const file = createFile();
+  file.sfc = await parseSfcFile(file.path, "<template><div /></template>");
+  file.scriptAst = parseScript("app.ts", 'import "vue"');
+  const events: string[] = [];
+
+  await runVisitor(
+    {
+      async SFC() {
+        await Promise.resolve();
+        events.push("sfc");
+      },
+      ScriptNode(node: { type: string }) {
+        events.push(node.type);
+      },
+      ImportDeclaration() {
+        events.push("import");
+      },
+      TemplateNode(node: { type: string }) {
+        events.push(node.type);
+      },
+    },
+    file,
+  );
+
+  expect(events).toEqual([
+    "sfc",
+    "Program",
+    "ImportDeclaration",
+    "import",
+    "Literal",
+    "VDocumentFragment",
+  ]);
+});


### PR DESCRIPTION
Every file visitor traversed both script and template ASTs, including visitors that only needed SFC metadata or project hooks. Traverse a tree only when the visitor has a corresponding hook, preserving hook order and script parent links.

Add nine regression tests and a repeatable benchmark on a parsed Vue component with 200 bindings. Seven traversal tests fail on the original implementation and pass with the guards.

On the shared Linux server, the SFC-only microbenchmark fell from about 2.62 ms to 0.0019 ms per visit; template-only visits fell from about 1.86 ms to 1.08 ms. These measure visitor dispatch, not total Doctor Run time, and server contention affected timing variance.

Validation: 78 core/Vue tests, scoped lint/format, and JS/declaration build pass. A broader run passed 331 tests; six tests that exceeded their default 5-second limits passed when rerun sequentially with 30-second limits. Nuxt fixture setup still exceeded 60 seconds under server load. The unchanged baseline passed all 344 tests before parallel verification began.
