### PR TITLE
test: verify packed exports on Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/package-compatibility.yml
+++ b/.github/workflows/package-compatibility.yml
@@ -1,0 +1,30 @@
+name: Package Compatibility
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: ${{ matrix.os }} / Node ${{ matrix.node }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: ["22.20.0", "24"]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test:pack

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -13,7 +13,11 @@ permissions:
   pull-requests: write
 
 jobs:
+  compatibility:
+    uses: ./.github/workflows/package-compatibility.yml
+
   publish:
+    needs: compatibility
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
   actions: read
 
 jobs:
+  compatibility:
+    uses: ./.github/workflows/package-compatibility.yml
+
   check:
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +29,7 @@ jobs:
       - run: pnpm release:check
 
   publish:
-    needs: check
+    needs: [check, compatibility]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/scripts/test-packed-cli.mjs
+++ b/scripts/test-packed-cli.mjs
@@ -10,13 +10,16 @@ const cacheDirectory = join(homedir(), ".cache");
 mkdirSync(cacheDirectory, { recursive: true });
 const temporary = mkdtempSync(join(cacheDirectory, "vite-doctor-pack-"));
 const packDirectory = join(temporary, "pack");
-const fixture = join(temporary, "fixture");
+const fixture = join(temporary, "fixture with spaces");
 const env = { ...process.env, CI: "1", NO_COLOR: "1" };
+const packageManager = process.env.npm_execpath;
+const pnpmCommand = packageManager ? process.execPath : "pnpm";
+const pnpmArgs = (args) => (packageManager ? [packageManager, ...args] : args);
 
 try {
   mkdirSync(packDirectory);
   mkdirSync(fixture);
-  execFileSync("pnpm", ["pack", "--pack-destination", packDirectory], {
+  execFileSync(pnpmCommand, pnpmArgs(["pack", "--pack-destination", packDirectory]), {
     cwd: root,
     env,
     stdio: "pipe",
@@ -29,11 +32,12 @@ try {
     join(temporary, "package.json"),
     `${JSON.stringify({ private: true, dependencies: { nuxt: nuxt.version, "vite-doctor": `file:${tarball}` } }, null, 2)}\n`,
   );
-  execFileSync("pnpm", ["install", "--ignore-scripts", "--prefer-offline"], {
+  execFileSync(pnpmCommand, pnpmArgs(["install", "--ignore-scripts", "--prefer-offline"]), {
     cwd: temporary,
     env,
     stdio: "pipe",
   });
+  verifyExports();
   writeFileSync(
     join(fixture, "package.json"),
     `${JSON.stringify({ private: true, dependencies: { nuxt: nuxt.version } }, null, 2)}\n`,
@@ -41,6 +45,7 @@ try {
   );
   writeFileSync(join(fixture, "nuxt.config.ts"), "export default defineNuxtConfig({})\n");
 
+  verifyDoctor(["exec", "vite-doctor", fixture, "--format", "agent", "--no-cache"]);
   verifyDoctor(["exec", "nuxt-doctor", fixture, "--format", "agent", "--no-cache"]);
   verifyDoctor(["nuxt", "doctor", fixture, "--format", "agent", "--no-cache"]);
   mkdirSync(join(fixture, "app/pages"), { recursive: true });
@@ -56,15 +61,18 @@ try {
     "agent",
     "--no-cache",
   ];
+  verifyDoctor(["exec", "vite-doctor", ...findingArgs], [1], "NUXT0029");
   verifyDoctor(["exec", "nuxt-doctor", ...findingArgs], [1], "NUXT0029");
   verifyDoctor(["nuxt", "doctor", ...findingArgs], [0, 1], "NUXT0029");
-  process.stdout.write("Packed Doctor CLI checks passed.\n");
+  process.stdout.write(
+    `Packed Doctor CLI checks passed on ${process.platform}, Node ${process.versions.node}.\n`,
+  );
 } finally {
   rmSync(temporary, { recursive: true, force: true });
 }
 
 function verifyDoctor(args, expectedStatuses = [0], expectedCode) {
-  const result = spawnSync("pnpm", args, {
+  const result = spawnSync(pnpmCommand, pnpmArgs(args), {
     cwd: temporary,
     env,
     encoding: "utf8",
@@ -92,4 +100,68 @@ function verifyDoctor(args, expectedStatuses = [0], expectedCode) {
     assert.equal(report.status, "clean");
     assert.deepEqual(report.diagnostics, []);
   }
+}
+
+function verifyExports() {
+  const manifest = JSON.parse(
+    readFileSync(join(temporary, "node_modules/vite-doctor/package.json"), "utf8"),
+  );
+  const subpaths = Object.keys(manifest.exports).filter((subpath) => subpath !== "./package.json");
+  const specifiers = subpaths.map((subpath) =>
+    subpath === "." ? manifest.name : `${manifest.name}/${subpath.slice(2)}`,
+  );
+  const runtimeImports = specifiers
+    .filter((specifier) => specifier !== `${manifest.name}/cli`)
+    .map((specifier) => `await import(${JSON.stringify(specifier)});`)
+    .join("\n");
+  writeFileSync(join(temporary, "imports.mjs"), `${runtimeImports}\n`);
+  execFileSync(process.execPath, [join(temporary, "imports.mjs")], {
+    cwd: temporary,
+    env,
+    stdio: "inherit",
+  });
+
+  const typeImports = specifiers.map(
+    (specifier, index) =>
+      `import * as entry${index} from ${JSON.stringify(specifier)}; export { entry${index} };`,
+  );
+  writeFileSync(
+    join(temporary, "consumer.mts"),
+    `${typeImports.join("\n")}\n` +
+      'import { doctor, defineDoctorConfig } from "vite-doctor";\n' +
+      'import { defineDoctorExtension } from "vite-doctor/extension";\n' +
+      'doctor({ config: defineDoctorConfig({ extends: ["vite/recommended"] }), extensions: [defineDoctorExtension({ name: "consumer", setup() {} })] });\n',
+  );
+  for (const [module, moduleResolution] of [
+    ["NodeNext", "NodeNext"],
+    ["ESNext", "Bundler"],
+  ]) {
+    writeFileSync(
+      join(temporary, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module,
+          moduleResolution,
+          target: "ESNext",
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          types: [],
+        },
+        files: ["consumer.mts"],
+      }),
+    );
+    execFileSync(
+      process.execPath,
+      [join(root, "node_modules/typescript/bin/tsc"), "-p", join(temporary, "tsconfig.json")],
+      {
+        cwd: temporary,
+        env,
+        stdio: "inherit",
+      },
+    );
+  }
+  process.stdout.write(
+    `Verified ${specifiers.length} packed exports with NodeNext and Bundler declarations.\n`,
+  );
 }


### PR DESCRIPTION
Packed checks covered only the Nuxt command paths, and CI tested one Linux runtime. Verify installed runtime imports and declaration resolution for all 18 public exports in NodeNext and Bundler mode, plus clean/finding exits through `vite-doctor`, the Nuxt shim, and `nuxt doctor`, using project paths containing spaces.

Run pnpm through its JavaScript entrypoint so subprocess spawning also works on Windows. Gate preview and release publication on an installed-package matrix: Linux, macOS, and Windows with Node 22.20 and 24.

Validation: package/declaration build, expanded packed checks on Linux Node 22.20 and 24.19, focused lint/format, and pre-commit checks pass. All six CI artifact combinations passed: Linux, macOS, and Windows on Node 22.20 and 24. The bundling audit found no broken exports or justified runtime bundling change.
