### PR TITLE
feat: diagnose unsupported import.meta.glob patterns

### DIFF
--- a/docs/rules/metadata.ts
+++ b/docs/rules/metadata.ts
@@ -1182,6 +1182,28 @@ export const ruleDocumentationMetadata = {
       },
     ],
   },
+  "vite/imports/require-static-glob-pattern": {
+    description:
+      "Reports import.meta.glob patterns that Vite cannot transform into module imports.",
+    why: "Vite expands import.meta.glob during development and production builds. Its first argument must contain string literals, an array of string literals, or template literals without interpolation. Variables, concatenation, interpolated templates, and array spreads are unsupported even when their values are constant. Vite 7 rejects them during the transform; Vite 8 can instead omit their matching modules from the generated map.",
+    recommendedReplacement:
+      "Write the patterns directly inside import.meta.glob. To choose a module at runtime, use a literal glob to build the module map, then select a key from that map.",
+    examples: [
+      {
+        title: "Inline constant patterns",
+        language: "ts",
+        invalid: "const pattern = './pages/*.vue'\nconst pages = import.meta.glob(pattern)",
+        valid: "const pages = import.meta.glob('./pages/*.vue')",
+      },
+      {
+        title: "Select a module after expanding a literal glob",
+        language: "ts",
+        invalid: "const loadPage = (name: string) => import.meta.glob(`./pages/${name}.vue`)",
+        valid:
+          "const pages = import.meta.glob('./pages/*.vue')\nconst loadPage = (name: string) => pages[`./pages/${name}.vue`]?.()",
+      },
+    ],
+  },
   "vite/assets/no-dynamic-new-url": {
     description: "Flags dynamic new URL in Vite assets code before it leaks into runtime behavior.",
     why: "Vite configuration runs in both dev and build pipelines. Narrow, explicit settings reduce surprises across SSR, workers, and local file access.",

--- a/src/core/diagnostic-code-map.ts
+++ b/src/core/diagnostic-code-map.ts
@@ -70,6 +70,7 @@ export const allDoctorDiagnosticRegistry = defineDoctorDiagnostics([
   { code: "VITE0019", ruleId: "vite/worker/no-dynamic-worker-url" },
   { code: "VITE0020", ruleId: "vite/worker/no-node-api-in-worker" },
   { code: "VITE0021", ruleId: "vite/worker/require-worker-url-pattern" },
+  { code: "VITE0022", ruleId: "vite/imports/require-static-glob-pattern" },
   { code: "TS0001", ruleId: "typescript/evidence/no-chained-type-assertions" },
   { code: "TS0002", ruleId: "typescript/evidence/no-object-parameters" },
   { code: "TS0003", ruleId: "typescript/evidence/no-unknown-type-aliases" },

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -22,6 +22,7 @@ export const viteDiagnosticRegistry = defineDoctorDiagnostics([
   { code: "VITE0019", ruleId: "vite/worker/no-dynamic-worker-url" },
   { code: "VITE0020", ruleId: "vite/worker/no-node-api-in-worker" },
   { code: "VITE0021", ruleId: "vite/worker/require-worker-url-pattern" },
+  { code: "VITE0022", ruleId: "vite/imports/require-static-glob-pattern" },
 ]);
 
 export const diagnostics = viteDiagnosticRegistry.diagnostics;

--- a/src/rule-packs/vite/rules/imports.ts
+++ b/src/rule-packs/vite/rules/imports.ts
@@ -1,0 +1,67 @@
+import { createRule } from "../../../core/index.js";
+import { diagnostics } from "../../../diagnostics.js";
+import { memberPath, staticString, type AnyNode } from "./shared.js";
+
+export const requireStaticGlobPattern = createRule({
+  meta: {
+    id: "vite/imports/require-static-glob-pattern",
+    title: "Use literal patterns in import.meta.glob",
+    category: "imports",
+    severity: "error",
+    docsUrl: "https://vite.dev/guide/features#glob-import-caveats",
+    requires: { script: true },
+  },
+  create(ctx) {
+    return {
+      ScriptNode(node: AnyNode) {
+        if (node.type !== "CallExpression") return;
+        const callee = node.callee;
+        if (
+          callee?.type !== "MemberExpression" ||
+          callee.computed ||
+          memberPath(callee) !== "import.meta.glob"
+        )
+          return;
+        const pattern = unwrapTypeExpression(node.arguments[0]);
+        if (isLiteralPattern(pattern)) return;
+        if (
+          pattern?.type === "ArrayExpression" &&
+          pattern.elements.every((element: AnyNode) => !element || isLiteralPattern(element))
+        )
+          return;
+        ctx.report(
+          diagnostics.VITE0022({
+            why: "Vite requires literal string patterns in import.meta.glob; variables and other expressions can fail the transform or leave modules out of the generated map.",
+            fix: "Pass a string literal or an array of string literals directly to import.meta.glob. For runtime selection, use a literal glob and select from the returned module map.",
+          }),
+          {
+            ruleId: "vite/imports/require-static-glob-pattern",
+            severity: ctx.severity,
+            category: "imports",
+            file: ctx.file.path,
+            range: ctx.range(pattern ?? node),
+          },
+        );
+      },
+    };
+  },
+});
+
+function isLiteralPattern(node: AnyNode): boolean {
+  return staticString(unwrapTypeExpression(node)) !== null;
+}
+
+function unwrapTypeExpression(node: AnyNode): AnyNode {
+  while (
+    node &&
+    [
+      "TSAsExpression",
+      "TSTypeAssertion",
+      "TSSatisfiesExpression",
+      "TSNonNullExpression",
+      "ParenthesizedExpression",
+    ].includes(node.type)
+  )
+    node = node.expression;
+  return node;
+}

--- a/src/rule-packs/vite/rules/index.ts
+++ b/src/rule-packs/vite/rules/index.ts
@@ -14,6 +14,7 @@ export {
 export { noDynamicNewUrl, noPublicSrcImport, noSrcAbsolutePublicUrl } from "./assets.js";
 export { noDynamicWorkerUrl, noNodeApiInWorker, requireWorkerUrlPattern } from "./worker.js";
 export { noBrowserGlobalInSsrEntry } from "./ssr.js";
+export { requireStaticGlobPattern } from "./imports.js";
 export { noBroadFsAllow, noDisabledFsStrict } from "./server.js";
 export {
   requireDisposeForSideEffects,
@@ -38,6 +39,7 @@ import {
 import { noDynamicNewUrl, noPublicSrcImport, noSrcAbsolutePublicUrl } from "./assets.js";
 import { noDynamicWorkerUrl, noNodeApiInWorker, requireWorkerUrlPattern } from "./worker.js";
 import { noBrowserGlobalInSsrEntry } from "./ssr.js";
+import { requireStaticGlobPattern } from "./imports.js";
 import { noBroadFsAllow, noDisabledFsStrict } from "./server.js";
 import {
   requireDisposeForSideEffects,
@@ -67,6 +69,7 @@ const rules = [
   requirePluginName,
   preferTransformFilter,
   requireDisposeForSideEffects,
+  requireStaticGlobPattern,
 ];
 
 const recommended = [
@@ -83,6 +86,7 @@ const recommended = [
   noDisabledFsStrict,
   noBroadFsAllow,
   requireDisposeForSideEffects,
+  requireStaticGlobPattern,
 ].map((rule) => rule.meta.id);
 
 const viteRulePack = defineRulePack({

--- a/tests/vite/glob-imports.test.ts
+++ b/tests/vite/glob-imports.test.ts
@@ -13,7 +13,6 @@ describe("Vite glob imports", () => {
     "...patterns",
     "42",
     "null",
-    "",
     "pattern as string",
   ])("reports a pattern that Vite cannot transform: %s", async (pattern) => {
     const result = await runProjectFixture({
@@ -35,6 +34,19 @@ const pages = import.meta.glob(${pattern})`,
       range: { line: 4 },
     });
     expect(result.diagnostics[0]?.file).toMatch(/src\/main\.ts$/);
+  });
+
+  test.each([
+    ["missing argument", "import.meta.glob()", ["VITE0022"]],
+    ["empty string literal", 'import.meta.glob("")', []],
+  ])("handles %s explicitly", async (_label, source, expectedCodes) => {
+    const result = await runProjectFixture({
+      framework: "vite",
+      rules: [requireStaticGlobPattern],
+      files: { "src/main.ts": source },
+    });
+
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(expectedCodes);
   });
 
   test("accepts Vite's literal patterns and TypeScript assertions", async () => {

--- a/tests/vite/glob-imports.test.ts
+++ b/tests/vite/glob-imports.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vite-plus/test";
+import { runProjectFixture } from "../../src/core/testkit.ts";
+import { requireStaticGlobPattern, viteRulePack } from "../../src/rules.ts";
+import { diagnosticsCollectionSource, getDiagnosticDocuments } from "../../docs/rules/source.ts";
+
+describe("Vite glob imports", () => {
+  test.each([
+    "pattern",
+    "`./pages/${name}.ts`",
+    "'./pages/' + name + '.ts'",
+    "['./pages/*.ts', pattern]",
+    "[...patterns]",
+    "...patterns",
+    "42",
+    "null",
+    "",
+    "pattern as string",
+  ])("reports a pattern that Vite cannot transform: %s", async (pattern) => {
+    const result = await runProjectFixture({
+      framework: "vite",
+      rules: [requireStaticGlobPattern],
+      files: {
+        "src/main.ts": `const pattern = './pages/*.ts'
+const patterns = ['./pages/*.ts']
+const name = 'home'
+const pages = import.meta.glob(${pattern})`,
+      },
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "VITE0022",
+      ruleId: "vite/imports/require-static-glob-pattern",
+      severity: "error",
+      range: { line: 4 },
+    });
+    expect(result.diagnostics[0]?.file).toMatch(/src\/main\.ts$/);
+  });
+
+  test("accepts Vite's literal patterns and TypeScript assertions", async () => {
+    const result = await runProjectFixture({
+      framework: "vite",
+      rules: [requireStaticGlobPattern],
+      files: {
+        "src/main.ts": `const a = import.meta.glob('./pages/*.ts')
+const b = import.meta.glob(['./pages/*.ts', '!./pages/private/*.ts'])
+const c = import.meta.glob(\`./pages/*.ts\`, { eager: true })
+const d = import.meta.glob('./pages/*.ts' as const)
+const e = import.meta.glob(['./pages/*.ts'] satisfies string[])
+const f = import.meta.glob([, './pages/*.ts'])
+const g = import.meta.glob([])
+const h = import.meta.glob(['./pages/*.ts' as const])
+const i = import.meta.glob<string>('./pages/*.ts')
+const j = import.meta.glob((('./pages/*.ts' as string)!))`,
+      },
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test("does not mistake other glob APIs, strings, or comments for Vite glob calls", async () => {
+    const result = await runProjectFixture({
+      framework: "vite",
+      rules: [requireStaticGlobPattern],
+      files: {
+        "src/main.ts": `const files = glob(pattern)
+const other = tools.glob(pattern)
+const computed = import.meta[glob](pattern)
+const text = 'import.meta.glob(pattern)'
+// import.meta.glob(pattern)`,
+      },
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test("reports Vue script patterns with their source location", async () => {
+    const result = await runProjectFixture({
+      framework: "vite",
+      rules: [requireStaticGlobPattern],
+      files: {
+        "src/App.vue": `<script setup lang="ts">
+const pattern = './pages/*.vue'
+const pages = import.meta.glob(pattern)
+</script>
+<template><div /></template>`,
+      },
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "VITE0022",
+      range: { line: 3, column: 32 },
+    });
+  });
+
+  test("enables the rule by default and generates its Diagnostic Reference", async () => {
+    expect(viteRulePack.presets?.recommended).toContain(requireStaticGlobPattern.meta.id);
+    expect(getDiagnosticDocuments()).toContainEqual(
+      expect.objectContaining({
+        code: "VITE0022",
+        ruleId: requireStaticGlobPattern.meta.id,
+        path: "/diagnostics/VITE0022",
+      }),
+    );
+    const page = await diagnosticsCollectionSource.getItem("diagnostics/VITE0022.md");
+    expect(page).toContain("import.meta.glob");
+    expect(page).toContain("module map");
+  });
+});


### PR DESCRIPTION
Add recommended Rule `vite/imports/require-static-glob-pattern` (`VITE0022`) for unsupported `import.meta.glob` arguments: variables, concatenation, interpolated templates, spreads, and non-string values. Literal strings/arrays and TypeScript assertions remain valid. Include Vue script locations and generated Diagnostic Reference content.

Real production builds consumed the resulting module map: stock Vite 7.3.1 rejected a variable pattern, while stock Vite 8.0.0 silently emitted an empty map despite an existing matching file. The literal-pattern control included the file in both versions. The repository's Vite+ build was also exercised.

Validation: 36 focused tests across new glob cases, existing Vite rules, and the docs catalog pass, as do the package/declaration build and type-aware lint. A broad local run hit existing 5-second test and 60-second Nuxt setup timeouts under shared-server load; focused verification was rerun sequentially with a 30-second test limit.
