### PR TITLE
fix: preserve diagnostic details in baseline fingerprints

### DIFF
--- a/src/core/internal/diagnostics.ts
+++ b/src/core/internal/diagnostics.ts
@@ -167,7 +167,7 @@ export function createDiagnosticFingerprint(
 ): string {
   const rel = relative(root, diagnostic.file);
   const anchor = nearestAnchor(file.text, diagnostic.range?.start ?? 0);
-  const message = diagnostic.why.replace(/\s+/g, " ").replace(/['"`][^'"`]+['"`]/g, '""');
+  const message = diagnostic.why.replace(/\s+/g, " ");
   return sha256(`${diagnostic.ruleId}:${rel}:${anchor}:${message}`);
 }
 

--- a/tests/core/diagnostic-fingerprints.test.ts
+++ b/tests/core/diagnostic-fingerprints.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "pathe";
+import { afterEach, expect, test } from "vite-plus/test";
+import { runDoctor } from "../../src/core/index.ts";
+
+const roots: string[] = [];
+const ruleId = "workspace/dead-code/unresolved-import";
+
+function fixture(source: string) {
+  const root = mkdtempSync(join(tmpdir(), "doctor-fingerprints-"));
+  roots.push(root);
+  writeFileSync(join(root, "package.json"), JSON.stringify({ type: "module" }));
+  writeFileSync(join(root, "index.ts"), source);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test.each([" ", "\n"])(
+  "distinct unresolved imports have distinct fingerprints with separator %j",
+  async (separator) => {
+    const root = fixture(["import './missing-one';", "import './missing-two';"].join(separator));
+    const result = await runDoctor({ root, analyses: "dead-code", cache: false });
+    const diagnostics = result.diagnostics.filter((diagnostic) => diagnostic.ruleId === ruleId);
+    expect(diagnostics.map((diagnostic) => diagnostic.why)).toEqual([
+      'Import "./missing-one" could not be resolved.',
+      'Import "./missing-two" could not be resolved.',
+    ]);
+    expect(new Set(diagnostics.map((diagnostic) => diagnostic.fingerprint)).size).toBe(2);
+  },
+);
+
+test("a baseline for one missing import does not suppress a different missing import", async () => {
+  const root = fixture("import './missing-one';");
+  const options = { root, analyses: "dead-code", baseline: "baseline.json", cache: false };
+  const first = await runDoctor({ ...options, updateBaseline: true });
+  const original = first.diagnostics.find((diagnostic) => diagnostic.ruleId === ruleId)!;
+  writeFileSync(join(root, "index.ts"), "import './missing-one'; import './missing-two';");
+  const second = await runDoctor({ ...options, newOnly: true });
+  expect(second.diagnostics.filter((diagnostic) => diagnostic.ruleId === ruleId)).toMatchObject([
+    { why: 'Import "./missing-two" could not be resolved.' },
+  ]);
+  expect(
+    second.suppressedDiagnostics?.filter((diagnostic) => diagnostic.ruleId === ruleId),
+  ).toMatchObject([{ fingerprint: original.fingerprint, suppressionReason: "baseline" }]);
+});
+
+test("fingerprints survive repeated runs and insertion of unrelated lines", async () => {
+  const root = fixture("import './missing-one';");
+  const options = { root, analyses: "dead-code", cache: false };
+  const fingerprints = async () =>
+    (await runDoctor(options)).diagnostics
+      .filter((diagnostic) => diagnostic.ruleId === ruleId)
+      .map((diagnostic) => diagnostic.fingerprint);
+  const original = await fingerprints();
+  expect(original).toHaveLength(1);
+  expect(original[0]).toMatch(/^[a-f0-9]{64}$/);
+  expect(await fingerprints()).toEqual(original);
+  writeFileSync(join(root, "index.ts"), "// unrelated heading\n\nimport './missing-one';");
+  expect(await fingerprints()).toEqual(original);
+});

--- a/tests/vite/vite-rules.test.ts
+++ b/tests/vite/vite-rules.test.ts
@@ -55,11 +55,16 @@ export default defineConfig({
       },
     });
 
-    expect(result.diagnostics.map((item) => item.ruleId).sort()).toEqual([
-      "vite/define/no-runtime-object-define",
-      "vite/define/no-secret-define",
-      "vite/define/no-untyped-define",
-      "vite/define/no-unused-define",
+    expect(result.diagnostics.map(({ ruleId, why }) => `${ruleId}: ${why}`).sort()).toEqual([
+      'vite/define/no-runtime-object-define: Vite define "__OBJECT__" uses a non-primitive replacement value.',
+      'vite/define/no-secret-define: Vite define "__SECRET_TOKEN__" looks like a secret and will be bundled into client code.',
+      'vite/define/no-untyped-define: Vite define global "__OBJECT__" is not declared in a project .d.ts file.',
+      'vite/define/no-untyped-define: Vite define global "__SECRET_TOKEN__" is not declared in a project .d.ts file.',
+      'vite/define/no-untyped-define: Vite define global "__UNTYPED__" is not declared in a project .d.ts file.',
+      'vite/define/no-untyped-define: Vite define global "__UNUSED__" is not declared in a project .d.ts file.',
+      'vite/define/no-unused-define: Vite define constant "__OBJECT__" is configured but never referenced.',
+      'vite/define/no-unused-define: Vite define constant "__SECRET_TOKEN__" is configured but never referenced.',
+      'vite/define/no-unused-define: Vite define constant "__UNUSED__" is configured but never referenced.',
     ]);
   });
 
@@ -223,12 +228,14 @@ console.log(logo)`,
       },
     });
 
-    expect(result.diagnostics.map((item) => item.ruleId).sort()).toEqual([
-      "vite/env/no-broad-env-prefix",
-      "vite/env/no-client-secret-pattern",
-      "vite/env/no-empty-env-prefix",
-      "vite/server/no-broad-fs-allow",
-      "vite/server/no-disabled-fs-strict",
+    expect(result.diagnostics.map(({ ruleId, why }) => `${ruleId}: ${why}`).sort()).toEqual([
+      'vite/env/no-broad-env-prefix: Vite envPrefix "" is broad enough to expose unrelated variables.',
+      'vite/env/no-broad-env-prefix: Vite envPrefix "APP_" is broad enough to expose unrelated variables.',
+      "vite/env/no-client-secret-pattern: import.meta.env.APP_SECRET looks like a secret and may be exposed to the browser.",
+      'vite/env/no-empty-env-prefix: Vite envPrefix: "" exposes every environment variable to client code.',
+      'vite/server/no-broad-fs-allow: Vite server.fs.allow entry "/" is broader than a project path.',
+      'vite/server/no-broad-fs-allow: Vite server.fs.allow entry "/Users/maxi" is broader than a project path.',
+      "vite/server/no-disabled-fs-strict: Vite dev server filesystem strict mode is disabled.",
     ]);
   });
 });


### PR DESCRIPTION
Two different missing imports could collapse into one diagnostic, even on separate lines. After baselining the first, introducing the second could also produce no new finding: fingerprint generation removed every quoted value, making both messages identical.

Preserve quoted diagnostic details while retaining whitespace normalization and source anchors. Add real Doctor Run regressions for both same-line and separate-line imports, baseline/new-only behavior, repeated runs, and unrelated line insertion.

Validation: three regression cases failed before the fix. All four new tests and all 34 plumbing tests now pass, along with scoped type-aware lint and diff checks. Existing Vite fixtures now assert every distinct define key, environment prefix, and filesystem allow entry instead of relying on the old collapsed counts.

Existing baselines and fingerprint suppressions for messages containing quoted values must be regenerated. Retaining their old identity would preserve the collision.
