### PR TITLE
fix: follow lazy imports and re-exports in dead-code analysis

### DIFF
--- a/src/core/internal/facts.ts
+++ b/src/core/internal/facts.ts
@@ -17,6 +17,8 @@ import { createCacheKey, markSession, type ScanSession } from "./scan-session.js
 import { nativeMatch, sha256 } from "./utils.js";
 import { getNodeVisitorKeys, getTemplateVisitorKeys } from "./visitor-keys.js";
 
+const FILE_FACTS_VERSION = 2;
+
 export async function parseSourceFiles(session: ScanSession): Promise<void> {
   const started = performance.now();
   let fileId = 0;
@@ -36,7 +38,11 @@ async function parseSourceFile(
   const absolute = file.path;
   const text = readFileSync(absolute, "utf8");
   const hash = sha256(text);
-  const cacheKey = createCacheKey(session, "fileFacts", `${absolute}:${hash}`);
+  const cacheKey = createCacheKey(
+    session,
+    "fileFacts",
+    `${FILE_FACTS_VERSION}:${absolute}:${hash}`,
+  );
   const cachedFacts = session.cache.get<FileFacts>(cacheKey);
   const isVueSfc = absolute.endsWith(".vue");
   const sfc = isVueSfc ? await parseOptionalSfc(absolute, text, hash) : undefined;
@@ -150,6 +156,11 @@ function createFileFacts(
           name: "*",
           kind: node.exportKind === "type" ? "type" : "value",
           source: String(node.source?.value ?? ""),
+          range: nodeRange(session, file.path, text, node),
+        });
+      } else if (node.type === "ImportExpression") {
+        dynamicImports.push({
+          source: typeof node.source?.value === "string" ? node.source.value : null,
           range: nodeRange(session, file.path, text, node),
         });
       } else if (node.type === "CallExpression") {

--- a/src/core/internal/workspace-graph.ts
+++ b/src/core/internal/workspace-graph.ts
@@ -43,22 +43,33 @@ export function buildWorkspaceGraph(session: ScanSession): WorkspaceGraph {
         specifier: item.source,
         kind: item.kind === "type" ? "type-import" : "import",
       });
-      if (target !== undefined) {
-        const importers = importersByFile.get(target) ?? [];
-        importers.push(fact.fileId);
-        importersByFile.set(target, importers);
-      }
       for (const specifier of item.specifiers) {
         const refs = refsByExport.get(specifier) ?? [];
         refs.push({ fileId: fact.fileId, range: item.range });
         refsByExport.set(specifier, refs);
       }
     }
+    for (const item of fact.dynamicImports) {
+      if (item.source === null) continue;
+      importEdges.push({
+        from: fact.fileId,
+        to: resolveImportTarget(session, fact, item.source, byRelativePath),
+        specifier: item.source,
+        kind: "dynamic-import",
+      });
+    }
     for (const item of fact.calls) {
       const refs = refsByExport.get(item.name) ?? [];
       refs.push({ fileId: fact.fileId, range: item.range });
       refsByExport.set(item.name, refs);
     }
+  }
+
+  for (const edge of [...importEdges, ...exportEdges]) {
+    if (edge.to === undefined) continue;
+    const importers = importersByFile.get(edge.to) ?? [];
+    importers.push(edge.from);
+    importersByFile.set(edge.to, importers);
   }
 
   const virtualRoots = createVirtualRoots(session, fileIdsByPath);
@@ -81,7 +92,7 @@ export function buildWorkspaceGraph(session: ScanSession): WorkspaceGraph {
     reverseIndex: { importersByFile, refsByExport, exportsByName },
     sccs: computeSccs(
       session.facts.map((fact) => fact.fileId),
-      importEdges,
+      [...importEdges.filter((edge) => edge.kind !== "dynamic-import"), ...exportEdges],
     ),
   };
 }
@@ -256,9 +267,11 @@ function runDeadCodeRules(session: ScanSession, graph: WorkspaceGraph) {
   const live = reachableFiles(graph);
   const packageDeps = readPackageDeps(session.root);
   const importedPackages = new Set<string>();
+  const byRelativePath = new Map(session.facts.map((fact) => [fact.relativePath, fact.fileId]));
 
   for (const fact of session.facts) {
-    for (const item of fact.imports) {
+    for (const item of [...fact.imports, ...fact.exports, ...fact.dynamicImports]) {
+      if (!item.source) continue;
       if (
         !item.source.startsWith(".") &&
         !item.source.startsWith("~/") &&
@@ -270,12 +283,7 @@ function runDeadCodeRules(session: ScanSession, graph: WorkspaceGraph) {
         isLocalSpecifier(item.source) &&
         !isGeneratedOrAssetImport(item.source) &&
         !isLikelyForeignFrameworkFile(session, fact.relativePath, packageDeps) &&
-        resolveImportTarget(
-          session,
-          fact,
-          item.source,
-          new Map(session.facts.map((f) => [f.relativePath, f.fileId])),
-        ) === undefined
+        resolveImportTarget(session, fact, item.source, byRelativePath) === undefined
       ) {
         pushDiagnostic(session, {
           ruleId: "workspace/dead-code/unresolved-import",
@@ -483,6 +491,13 @@ function selectedAnalyses(session: ScanSession): Set<string> {
 
 function reachableFiles(graph: WorkspaceGraph): Set<number> {
   const live = new Set<number>();
+  const targetsByFile = new Map<number, number[]>();
+  for (const edge of [...graph.importEdges, ...graph.exportEdges]) {
+    if (edge.to === undefined) continue;
+    const targets = targetsByFile.get(edge.from) ?? [];
+    targets.push(edge.to);
+    targetsByFile.set(edge.from, targets);
+  }
   const queue = graph.virtualRoots.flatMap((root) =>
     root.fileId === undefined ? [] : [root.fileId],
   );
@@ -490,13 +505,11 @@ function reachableFiles(graph: WorkspaceGraph): Set<number> {
     if (fact.exports.some((item) => graph.reverseIndex.refsByExport.has(item.name)))
       queue.push(fact.fileId);
   }
-  while (queue.length) {
-    const id = queue.shift()!;
+  for (let index = 0; index < queue.length; index++) {
+    const id = queue[index]!;
     if (live.has(id)) continue;
     live.add(id);
-    for (const edge of graph.importEdges) {
-      if (edge.from === id && edge.to !== undefined && !live.has(edge.to)) queue.push(edge.to);
-    }
+    for (const target of targetsByFile.get(id) ?? []) if (!live.has(target)) queue.push(target);
   }
   return live;
 }

--- a/tests/core/workspace-graph.test.ts
+++ b/tests/core/workspace-graph.test.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { expect, test } from "vite-plus/test";
+import { runViteDoctor } from "../../src/doctor.ts";
+
+test.each(["src/main.ts", "src/main.js", "app.vue"])(
+  "keeps lazy-loaded modules reachable from %s",
+  async (entry) => {
+    await withProject(
+      {
+        [entry]: entry.endsWith(".vue")
+          ? '<script setup>void import("./src/lazy.ts")</script>'
+          : 'void import("./lazy.ts")',
+        "src/lazy.ts": 'import "./effect.ts"; export default 1',
+        "src/effect.ts": 'console.log("loaded")',
+        "src/unused.ts": 'console.log("unused")',
+      },
+      async (root) => {
+        const result = await runViteDoctor({ root, analyses: "dead-code", cache: false });
+        expect(
+          result.diagnostics
+            .filter((item) => item.ruleId === "workspace/dead-code/unused-file")
+            .map((item) => item.file),
+        ).toEqual([join(root, "src/unused.ts")]);
+      },
+    );
+  },
+);
+
+test("follows named and star re-exports from a package entrypoint", async () => {
+  await withProject(
+    {
+      "src/index.ts": 'export * from "./barrel.ts"',
+      "src/barrel.ts": 'export { value } from "./value.ts"',
+      "src/value.ts": "export const value = 1",
+    },
+    async (root) => {
+      const result = await runViteDoctor({ root, analyses: "dead-code", cache: false });
+      expect(
+        result.diagnostics.filter((item) => item.ruleId === "workspace/dead-code/unused-file"),
+      ).toEqual([]);
+    },
+  );
+});
+
+test("counts dynamic imports and re-exports when diagnosing dependencies", async () => {
+  await withProject(
+    {
+      "package.json": JSON.stringify({
+        dependencies: { "lazy-package": "1.0.0", "exported-package": "1.0.0" },
+      }),
+      "src/index.ts":
+        'void import("lazy-package"); export * from "exported-package"; void import("missing-package")',
+    },
+    async (root) => {
+      const result = await runViteDoctor({ root, analyses: "dead-code", cache: false });
+      expect(
+        result.diagnostics.filter(
+          (item) => item.ruleId === "workspace/dead-code/unused-dependency",
+        ),
+      ).toEqual([]);
+      expect(
+        result.diagnostics
+          .filter((item) => item.ruleId === "workspace/dead-code/unlisted-dependency")
+          .map((item) => item.message),
+      ).toEqual([
+        'Package "missing-package" is imported but is not listed in package.json dependencies.',
+      ]);
+    },
+  );
+});
+
+test.each(['void import("./missing.ts")', 'export * from "./missing.ts"'])(
+  "reports a missing dependency for %s without guessing expressions",
+  async (statement) => {
+    await withProject(
+      { "src/main.ts": `${statement};\nconst target = "./optional.ts";\nvoid import(target)` },
+      async (root) => {
+        const result = await runViteDoctor({ root, analyses: "dead-code", cache: false });
+        expect(
+          result.diagnostics
+            .filter((item) => item.ruleId === "workspace/dead-code/unresolved-import")
+            .map((item) => item.message),
+        ).toEqual(['Import "./missing.ts" could not be resolved.']);
+      },
+    );
+  },
+);
+
+test("finds cycles through re-exports", async () => {
+  await withProject(
+    {
+      "src/index.ts": 'export * from "./cycle.ts"',
+      "src/cycle.ts": 'import "./index.ts"',
+    },
+    async (root) => {
+      const result = await runViteDoctor({ root, analyses: "graph", cache: false });
+      expect(
+        result.diagnostics.filter(
+          (item) => item.ruleId === "workspace/dead-code/circular-dependency",
+        ),
+      ).toHaveLength(1);
+    },
+  );
+});
+
+test("does not turn lazy loading into a static dependency cycle", async () => {
+  await withProject(
+    {
+      "src/index.ts": 'export const load = () => import("./lazy.ts")',
+      "src/lazy.ts": 'import "./index.ts"',
+    },
+    async (root) => {
+      const result = await runViteDoctor({ root, analyses: "graph", cache: false });
+      expect(
+        result.diagnostics.filter(
+          (item) => item.ruleId === "workspace/dead-code/circular-dependency",
+        ),
+      ).toEqual([]);
+    },
+  );
+});
+
+async function withProject(files: Record<string, string>, run: (root: string) => Promise<void>) {
+  const root = await mkdtemp(join(tmpdir(), "vite-doctor-workspace-graph-"));
+  try {
+    for (const [file, contents] of Object.entries({ "package.json": "{}", ...files })) {
+      const target = join(root, file);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, contents);
+    }
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
Lazy-loaded modules and files behind re-export chains could be reported as unused. Dynamic imports were not extracted from the parser's ImportExpression nodes, and workspace reachability followed only static import edges. Dependency accounting also missed packages loaded or re-exported this way.

Extract literal dynamic imports, follow lazy and re-export edges for reachability and dependency diagnostics, and include re-exports in cycle detection while keeping lazy edges out of static cycles. Reuse a file lookup map and an adjacency index instead of rebuilding or scanning them during traversal. Bump the internal file-facts cache version so old cached facts do not hide dynamic imports.

Validation: four initial Doctor Run reproductions failed before the fix. All nine new regression cases and all 67 core tests pass, along with scoped type-aware lint and diff checks. Coverage includes TypeScript, JavaScript, Vue scripts, named/star re-exports, external dependencies, missing literal targets, nonliteral unknowns, and static versus lazy cycles. Core tests ran with two workers and a 30-second test limit under shared-server load.
