### PR TITLE
feat: diagnose local widen-then-assert flows

### DIFF
--- a/.changeset/anti-slop-widen-then-assert.md
+++ b/.changeset/anti-slop-widen-then-assert.md
@@ -1,0 +1,5 @@
+---
+"vite-doctor": minor
+---
+
+Add typescript/evidence/no-widen-then-assert to the TypeScript Strict Preset with Diagnostic Code TS0009. Detect immutable local values widened to a broad type and later asserted to a concrete type.

--- a/docs/app/utils/rule-catalog.test.ts
+++ b/docs/app/utils/rule-catalog.test.ts
@@ -1,3 +1,4 @@
+import { typescriptRulePack } from "../../../src/rule-packs/typescript/index.js";
 import { nextTick, ref } from "vue";
 import { expect, test } from "vite-plus/test";
 import {
@@ -77,7 +78,9 @@ test("rule source exposes canonical docs paths and framework counts", () => {
   expect(reports.all.catalogVersion).toBe(1);
   expect(reports.all.rules.length).toBeGreaterThan(0);
   expect(reports.all.rules.every((rule) => rule.docsPath?.startsWith("/"))).toBe(true);
-  expect(reports.typescript.rules).toHaveLength(8);
+  expect(reports.typescript.rules.map((rule) => rule.id).sort()).toEqual(
+    typescriptRulePack.rules.map((rule) => rule.meta.id).sort(),
+  );
   expect(reports.nuxt.rules.length).toBe(
     reports.vue.rules.length +
       reports.nitro.rules.length +

--- a/src/rule-packs/typescript/diagnostics.ts
+++ b/src/rule-packs/typescript/diagnostics.ts
@@ -15,6 +15,7 @@ export const typescriptDiagnosticRegistry = defineDoctorDiagnostics([
     code: "TS0008",
     ruleId: "typescript/strict/require-safety-comment-for-type-assertion",
   },
+  { code: "TS0009", ruleId: "typescript/evidence/no-widen-then-assert" },
 ]);
 
 export const diagnostics = typescriptDiagnosticRegistry.diagnostics;

--- a/src/rule-packs/typescript/rules/index.ts
+++ b/src/rule-packs/typescript/rules/index.ts
@@ -1,3 +1,4 @@
+export { noWidenThenAssert } from "./no-widen-then-assert.js";
 export { noCallerChosenResultType } from "./no-caller-chosen-result-type.js";
 export { noChainedTypeAssertions } from "./no-chained-type-assertions.js";
 export { noConditionalEmptyObjectSpread } from "./no-conditional-empty-object-spread.js";
@@ -17,9 +18,12 @@ import { noUnknownTypeAliases } from "./no-unknown-type-aliases.js";
 import { noUnvalidatedDeserialization } from "./no-unvalidated-deserialization.js";
 import { requireSafetyCommentForTypeAssertion } from "./require-safety-comment-for-type-assertion.js";
 
+import { noWidenThenAssert } from "./no-widen-then-assert.js";
+
 const recommendedRules = [noChainedTypeAssertions, noUnvalidatedDeserialization];
 
 const strictRules = [
+  noWidenThenAssert,
   noCallerChosenResultType,
   ...recommendedRules,
   noObjectParameters,

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -1,0 +1,272 @@
+import { getNodeVisitorKeys } from "../../../core/internal/visitor-keys.js";
+import { parameterType, type AnyNode } from "./shared.js";
+
+type Binding = {
+  node: AnyNode;
+  kind: string;
+  annotation?: AnyNode;
+  init?: AnyNode;
+  written: boolean;
+  owner: AnyNode;
+};
+type Scope = { parent?: Scope; owner: AnyNode; bindings: Map<string, Binding[]> };
+
+export function expression(node: AnyNode): AnyNode {
+  while (
+    node &&
+    [
+      "ParenthesizedExpression",
+      "ChainExpression",
+      "TSSatisfiesExpression",
+      "TSNonNullExpression",
+    ].includes(node.type)
+  )
+    node = node.expression;
+  return node;
+}
+
+export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | null {
+  node = expression(node);
+  if (node?.type !== "MemberExpression" || node.optional) return null;
+  const name =
+    !node.computed && node.property?.type === "Identifier"
+      ? node.property.name
+      : node.property?.type === "Literal"
+        ? node.property.value
+        : null;
+  return typeof name === "string" ? { object: expression(node.object), name } : null;
+}
+
+export function createLocalEvidence(program: AnyNode) {
+  const scopes = new WeakMap<object, Scope>();
+  const writes: AnyNode[] = [];
+  const root: Scope = { owner: program, bindings: new Map() };
+  function bind(pattern: AnyNode, scope: Scope, info: Omit<Binding, "node" | "written" | "owner">) {
+    if (!pattern) return;
+    if (pattern.type === "Identifier") {
+      const bindings = scope.bindings.get(pattern.name) ?? [];
+      bindings.push({
+        ...info,
+        annotation: pattern.typeAnnotation?.typeAnnotation ?? info.annotation,
+        node: pattern,
+        written: false,
+        owner: scope.owner,
+      });
+      scope.bindings.set(pattern.name, bindings);
+    } else if (pattern.type === "AssignmentPattern") bind(pattern.left, scope, { kind: info.kind });
+    else if (pattern.type === "RestElement" || pattern.type === "TSParameterProperty")
+      bind(pattern.argument ?? pattern.parameter, scope, { kind: info.kind });
+    else if (pattern.type === "ArrayPattern")
+      for (const item of pattern.elements) bind(item, scope, { kind: info.kind });
+    else if (pattern.type === "ObjectPattern")
+      for (const item of pattern.properties)
+        bind(item.value ?? item.argument, scope, { kind: info.kind });
+  }
+  function collect(node: AnyNode, outer: Scope) {
+    if (!node?.type) return;
+    if (
+      [
+        "FunctionDeclaration",
+        "ClassDeclaration",
+        "TSTypeAliasDeclaration",
+        "TSInterfaceDeclaration",
+        "TSEnumDeclaration",
+        "TSModuleDeclaration",
+        "TSImportEqualsDeclaration",
+      ].includes(node.type)
+    )
+      bind(node.id, outer, { kind: "other" });
+    if (
+      ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
+    )
+      bind(node.local, outer, { kind: "other" });
+    const isFunction = [
+      "FunctionDeclaration",
+      "FunctionExpression",
+      "ArrowFunctionExpression",
+    ].includes(node.type);
+    const scoped =
+      isFunction ||
+      [
+        "BlockStatement",
+        "StaticBlock",
+        "ForStatement",
+        "ForOfStatement",
+        "ForInStatement",
+        "SwitchStatement",
+        "CatchClause",
+        "ClassExpression",
+        "TSModuleBlock",
+      ].includes(node.type) ||
+      node.typeParameters?.params?.length;
+    const scope = scoped
+      ? {
+          parent: outer,
+          owner: isFunction ? node : outer.owner,
+          bindings: new Map<string, Binding[]>(),
+        }
+      : outer;
+    if (isFunction) {
+      if (node.type === "FunctionExpression") bind(node.id, scope, { kind: "other" });
+      for (const parameter of node.params)
+        bind(parameter, scope, { kind: "parameter", annotation: parameterType(parameter) });
+    }
+    if (node.type === "ClassExpression") bind(node.id, scope, { kind: "other" });
+    if (node.type === "CatchClause") bind(node.param, scope, { kind: "other" });
+    for (const parameter of node.typeParameters?.params ?? [])
+      bind(parameter.name, scope, { kind: "other" });
+    scopes.set(node, scope);
+    if (node.type === "VariableDeclaration") {
+      let target = scope;
+      if (node.kind === "var")
+        while (target.parent && target.parent.owner === target.owner) target = target.parent;
+      for (const declaration of node.declarations)
+        bind(declaration.id, target, { kind: node.kind, init: declaration.init });
+    }
+    if (node.type === "AssignmentExpression") writes.push(node.left);
+    if (node.type === "UpdateExpression") writes.push(node.argument);
+    if (
+      ["ForOfStatement", "ForInStatement"].includes(node.type) &&
+      node.left?.type !== "VariableDeclaration"
+    )
+      writes.push(node.left);
+    for (const key of getNodeVisitorKeys(node)) {
+      const value = node[key];
+      for (const child of Array.isArray(value) ? value : [value]) collect(child, scope);
+    }
+  }
+  collect(program, root);
+  function binding(node: AnyNode): Binding | null {
+    node = expression(node);
+    if (node?.type !== "Identifier") return null;
+    for (let scope = scopes.get(node); scope; scope = scope.parent) {
+      const found = scope.bindings.get(node.name);
+      if (found)
+        return found.length === 1 ? found[0]! : { ...found[0]!, kind: "ambiguous", written: true };
+    }
+    return null;
+  }
+  function markWrite(node: AnyNode) {
+    if (!node) return;
+    if (node.type === "Identifier") {
+      const target = binding(node);
+      if (target) target.written = true;
+    } else if (node.type === "AssignmentPattern") markWrite(node.left);
+    else if (node.type === "RestElement") markWrite(node.argument);
+    else if (node.type === "ArrayPattern") for (const item of node.elements) markWrite(item);
+    else if (node.type === "ObjectPattern")
+      for (const item of node.properties) markWrite(item.value ?? item.argument);
+  }
+  for (const write of writes) markWrite(write);
+  function globalType(node: AnyNode, name: string): boolean {
+    if (
+      node?.type !== "TSTypeReference" ||
+      node.typeName?.type !== "Identifier" ||
+      node.typeName.name !== name
+    )
+      return false;
+    return !binding(node.typeName);
+  }
+  function broadType(node: AnyNode): boolean {
+    if (!node) return false;
+    if (["TSUnknownKeyword", "TSAnyKeyword", "TSObjectKeyword"].includes(node.type)) return true;
+    if (node.type === "TSParenthesizedType") return broadType(node.typeAnnotation);
+    if (node.type === "TSUnionType") return node.types.some((item: AnyNode) => broadType(item));
+    if (node.type === "TSTypeLiteral") return !node.members.length;
+    if (globalType(node, "Readonly")) return broadType(node.typeArguments?.params?.[0]);
+    if (!globalType(node, "Record")) return false;
+    const [key, value] = node.typeArguments?.params ?? [];
+    return (
+      ["TSStringKeyword", "TSNumberKeyword", "TSSymbolKeyword"].includes(key?.type) &&
+      broadType(value)
+    );
+  }
+  function arrayType(node: AnyNode): boolean {
+    if (node?.type === "TSArrayType" || node?.type === "TSTupleType") return true;
+    if (node?.type === "TSTypeOperator" && node.operator === "readonly")
+      return arrayType(node.typeAnnotation);
+    return globalType(node, "Array") || globalType(node, "ReadonlyArray");
+  }
+  function isArray(node: AnyNode, seen = new Set<Binding>()): boolean {
+    node = expression(node);
+    if (!node) return false;
+    if (node.type === "ArrayExpression") return true;
+    if (node.type === "Identifier") {
+      const target = binding(node);
+      if (!target || target.written || seen.has(target)) return false;
+      if (arrayType(target.annotation)) return true;
+      if (
+        target.annotation ||
+        target.kind !== "const" ||
+        !target.init ||
+        target.node.start >= node.start
+      )
+        return false;
+      return isArray(target.init, new Set([...seen, target]));
+    }
+    if (node.type === "CallExpression" && !node.optional) {
+      const method = arrayMethod(node.callee);
+      return (
+        !!method &&
+        [
+          "filter",
+          "map",
+          "flatMap",
+          "slice",
+          "concat",
+          "toSorted",
+          "toReversed",
+          "toSpliced",
+          "with",
+        ].includes(method.name) &&
+        isArray(method.object, seen)
+      );
+    }
+    return false;
+  }
+  function known(node: AnyNode, seen = new Set<Binding>()): boolean {
+    node = expression(node);
+    if (!node) return false;
+    if (
+      [
+        "Literal",
+        "ObjectExpression",
+        "ArrayExpression",
+        "ArrowFunctionExpression",
+        "FunctionExpression",
+      ].includes(node.type)
+    )
+      return true;
+    if (node.type !== "Identifier") return false;
+    const target = binding(node);
+    if (!target || target.written || seen.has(target)) return false;
+    if (target.annotation)
+      return (
+        [
+          "TSStringKeyword",
+          "TSNumberKeyword",
+          "TSBooleanKeyword",
+          "TSBigIntKeyword",
+          "TSSymbolKeyword",
+          "TSLiteralType",
+          "TSArrayType",
+          "TSTupleType",
+          "TSFunctionType",
+        ].includes(target.annotation.type) ||
+        (target.annotation.type === "TSTypeLiteral" && target.annotation.members.length > 0)
+      );
+    return (
+      target.kind === "const" &&
+      target.node.start < node.start &&
+      known(target.init, new Set([...seen, target]))
+    );
+  }
+  return {
+    binding,
+    broadType,
+    globalType,
+    isArray,
+    known,
+    owner: (node: AnyNode) => scopes.get(node)?.owner,
+  };
+}

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -224,7 +224,7 @@ export function createLocalEvidence(program: AnyNode) {
     }
     return false;
   }
-  function known(node: AnyNode, seen = new Set<Binding>()): boolean {
+  function known(node: AnyNode, owner: AnyNode, seen = new Set<Binding>()): boolean {
     node = expression(node);
     if (!node) return false;
     if (
@@ -239,7 +239,7 @@ export function createLocalEvidence(program: AnyNode) {
       return true;
     if (node.type !== "Identifier") return false;
     const target = binding(node);
-    if (!target || target.written || seen.has(target)) return false;
+    if (!target || target.owner !== owner || target.written || seen.has(target)) return false;
     if (target.annotation)
       return (
         [
@@ -258,7 +258,7 @@ export function createLocalEvidence(program: AnyNode) {
     return (
       target.kind === "const" &&
       target.node.start < node.start &&
-      known(target.init, new Set([...seen, target]))
+      known(target.init, owner, new Set([...seen, target]))
     );
   }
   return {

--- a/src/rule-packs/typescript/rules/no-widen-then-assert.ts
+++ b/src/rule-packs/typescript/rules/no-widen-then-assert.ts
@@ -1,0 +1,85 @@
+import { createRule } from "../../../core/index.js";
+import {
+  isTypeAssertion,
+  isConstAssertion,
+  isTypeScriptSource,
+  report,
+  type AnyNode,
+} from "./shared.js";
+import { createLocalEvidence, expression } from "./local-evidence.js";
+
+const ruleId = "typescript/evidence/no-widen-then-assert";
+
+export const noWidenThenAssert = createRule({
+  meta: {
+    id: "typescript/evidence/no-widen-then-assert",
+    title: "Keep known evidence through local assertions",
+    description:
+      "Detect immutable local values widened to a broad type and later asserted to a concrete type.",
+    why: "Widening a known value before asserting a new type separates the unsupported claim from its evidence. This rule follows immutable local aliases within one function; imported types and cross-function flows are outside its analysis.",
+    recommendedReplacement:
+      "Preserve the original inferred type, or validate the value before claiming a different type.",
+    examples: [
+      {
+        title: "Keep known evidence through local assertions",
+        language: "ts",
+        invalid:
+          "const value = { id: 1 }; const erased: unknown = value; const user = erased as User",
+        valid: "const value = { id: 1 }; const user = UserSchema.parse(value)",
+      },
+    ],
+    category: "evidence",
+    severity: "warn",
+    fixable: "structural-review",
+    docsUrl:
+      "https://github.com/dmmulroy/anti-slop/tree/c44ef22ca116d0ba62a3ff663a0bd13a3f3fa40b#rules",
+    requires: { script: true },
+    aiGeneratedCodeRisk: "high",
+  },
+  create(ctx) {
+    if (!isTypeScriptSource(ctx)) return;
+    let evidence: ReturnType<typeof createLocalEvidence>;
+    function widened(node: AnyNode, owner: AnyNode, seen = new Set<unknown>()): boolean {
+      node = expression(node);
+      const target = evidence.binding(node);
+      if (
+        !target ||
+        target.kind !== "const" ||
+        target.written ||
+        target.owner !== owner ||
+        seen.has(target) ||
+        target.node.start >= node.start
+      )
+        return false;
+      seen.add(target);
+      let initial = expression(target.init);
+      if (evidence.broadType(target.annotation)) return evidence.known(initial);
+      if (target.annotation) return false;
+      if (isTypeAssertion(initial) && evidence.broadType(initial.typeAnnotation))
+        return evidence.known(initial.expression);
+      return widened(initial, owner, seen);
+    }
+    return {
+      ScriptNode(node: AnyNode) {
+        if (node.type === "Program") {
+          evidence = createLocalEvidence(node);
+          return;
+        }
+        if (
+          !isTypeAssertion(node) ||
+          isConstAssertion(node) ||
+          evidence.broadType(node.typeAnnotation)
+        )
+          return;
+        if (!widened(node.expression, evidence.owner(node))) return;
+        report(
+          ctx,
+          node,
+          ruleId,
+          "This assertion claims a concrete type after an immutable local value discarded known type evidence.",
+          "Preserve the original type, or validate the value before asserting a different contract.",
+        );
+      },
+    };
+  },
+});

--- a/src/rule-packs/typescript/rules/no-widen-then-assert.ts
+++ b/src/rule-packs/typescript/rules/no-widen-then-assert.ts
@@ -53,10 +53,10 @@ export const noWidenThenAssert = createRule({
         return false;
       seen.add(target);
       let initial = expression(target.init);
-      if (evidence.broadType(target.annotation)) return evidence.known(initial);
+      if (evidence.broadType(target.annotation)) return evidence.known(initial, owner);
       if (target.annotation) return false;
       if (isTypeAssertion(initial) && evidence.broadType(initial.typeAnnotation))
-        return evidence.known(initial.expression);
+        return evidence.known(initial.expression, owner);
       return widened(initial, owner, seen);
     }
     return {

--- a/tests/rule-packs/typescript/widen-then-assert.test.ts
+++ b/tests/rule-packs/typescript/widen-then-assert.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "vite-plus/test";
+import { runProjectFixture } from "../../../src/core/testkit.js";
+import { noWidenThenAssert, typescriptRulePack } from "../../../src/rule-packs/typescript/index.js";
+import { getRuleDocuments, getDiagnosticDocuments } from "../../../docs/rules/source.js";
+
+const cases: [string, string, number][] = [
+  [
+    "annotation",
+    "const value = { id: 1 }; const erased: unknown = value; const claimed = erased as User",
+    1,
+  ],
+  [
+    "assertion",
+    "const value = { id: 1 }; const erased = value as unknown; const claimed = erased as User",
+    1,
+  ],
+  [
+    "alias chain",
+    "const erased: object = { id: 1 }; const alias = erased; const claimed = alias as User",
+    1,
+  ],
+  ["any", "const erased: any = [1]; const claimed = erased as string[]", 1],
+  [
+    "broad record",
+    "const erased: Record<string, unknown> = { id: 1 }; const claimed = erased as User",
+    1,
+  ],
+  ["same function", "function f() { const erased: unknown = { id: 1 }; return erased as User }", 1],
+  ["boundary", "const erased: unknown = JSON.parse(text); const claimed = erased as User", 0],
+  [
+    "imported value",
+    "import { value } from 'external'; const erased: unknown = value; const claimed = erased as User",
+    0,
+  ],
+  [
+    "mutable binding",
+    "let erased: unknown = { id: 1 }; erased = input; const claimed = erased as User",
+    0,
+  ],
+  ["closure", "const erased: unknown = { id: 1 }; function get() { return erased as User }", 0],
+  [
+    "shadowing",
+    "const erased: unknown = { id: 1 }; function get(erased: unknown) { return erased as User }",
+    0,
+  ],
+  ["broad target", "const erased: unknown = { id: 1 }; const claimed = erased as object", 0],
+  ["const target", "const erased: unknown = { id: 1 }; const claimed = erased as const", 0],
+  ["no widening", "const value = { id: 1 }; const claimed = value as User", 0],
+  [
+    "unresolved alias",
+    "type External = unknown; const value: External = input; const erased: unknown = value; const claimed = erased as User",
+    0,
+  ],
+];
+
+test.each(cases)("checks %s", async (_name, source, expected) => {
+  const result = await runProjectFixture({
+    framework: "vite",
+    rules: [noWidenThenAssert],
+    files: { "index.ts": source },
+  });
+  expect(result.diagnostics.map((item) => item.code)).toEqual(Array(expected).fill("TS0009"));
+});
+
+test("exports an opt-in rule with generated rule and diagnostic documentation", () => {
+  expect(typescriptRulePack.presets.strict).toContain(noWidenThenAssert.meta.id);
+  expect(typescriptRulePack.presets.recommended).not.toContain(noWidenThenAssert.meta.id);
+  expect(
+    getRuleDocuments().find((rule) => rule.id === noWidenThenAssert.meta.id)?.examples.length,
+  ).toBeGreaterThan(0);
+  expect(getDiagnosticDocuments().find((diagnostic) => diagnostic.code === "TS0009")?.ruleId).toBe(
+    noWidenThenAssert.meta.id,
+  );
+});
+
+test("reports TypeScript Vue scripts with source locations", async () => {
+  const result = await runProjectFixture({
+    rules: [noWidenThenAssert],
+    files: {
+      "App.vue":
+        '<template><p>Example</p></template>\n<script setup lang="ts">\n' +
+        cases[0]![1] +
+        "\n</script>",
+    },
+  });
+  expect(result.diagnostics.map((item) => item.code)).toEqual(["TS0009"]);
+  expect(result.diagnostics[0]?.range?.line).toBe(3);
+});
+
+test("leaves JavaScript-only sources outside the TypeScript Rule Pack", async () => {
+  const result = await runProjectFixture({
+    framework: "vite",
+    rules: [noWidenThenAssert],
+    files: {
+      "index.js":
+        "const values = [1]; values.filter(keep).map(transform); values.reduce((acc, item) => acc.concat(item), [])",
+    },
+  });
+  expect(result.diagnostics).toHaveLength(0);
+});

--- a/tests/rule-packs/typescript/widen-then-assert.test.ts
+++ b/tests/rule-packs/typescript/widen-then-assert.test.ts
@@ -26,6 +26,31 @@ const cases: [string, string, number][] = [
     1,
   ],
   ["same function", "function f() { const erased: unknown = { id: 1 }; return erased as User }", 1],
+  [
+    "outer function evidence",
+    "function outer() { const value = { id: 1 }; function inner() { const erased: unknown = value; return erased as User } }",
+    0,
+  ],
+  [
+    "outer evidence through local alias",
+    "const value = { id: 1 }; function inner() { const alias = value; const erased = alias as unknown; return erased as User }",
+    0,
+  ],
+  [
+    "outer annotated evidence",
+    "function outer(value: string) { return () => { const erased: unknown = value; return erased as User } }",
+    0,
+  ],
+  [
+    "same function evidence aliases",
+    "function inner() { const value = { id: 1 }; const alias = value; const erased = alias as unknown; return erased as User }",
+    1,
+  ],
+  [
+    "same function block evidence",
+    "function inner(value: string) { { const erased: unknown = value; return erased as User } }",
+    1,
+  ],
   ["boundary", "const erased: unknown = JSON.parse(text); const claimed = erased as User", 0],
   [
     "imported value",


### PR DESCRIPTION
Doctor catches adjacent assertion chains but misses `const erased: unknown = value; const result = erased as User`. Add a Strict Preset diagnostic that follows immutable local bindings back to known syntax evidence before a concrete assertion.

Supports broad annotations and broad assertions in initializers, immutable aliases, primitive/object/array/function syntax evidence, and TypeScript Vue scripts. Reassignments, imported or unresolved types, and assertions crossing the widened binding's function boundary are excluded. This is a conservative subset of upstream behavior; it does not provide full type or data-flow analysis.

Registers Diagnostic Code `TS0009`, public Rule Pack exports, rule metadata for generated Rule Catalog and Diagnostic Reference pages, and a changeset. Recommended Preset behavior remains unchanged; JavaScript-only sources stay outside the TypeScript Rule Pack.

The catalog test now compares documented rule IDs with registered rule IDs instead of fixing the TypeScript rule count at eight. The local-evidence helper is identical across the four new-rule PRs so it can be shared when they merge; each branch includes it and builds independently.

Validation: formatting, lint, declaration build, and all 414 tests passed across the runtime and documentation suites. The first full run exposed the obsolete catalog count; the corrected documentation suite passed on rerun. Tests include TypeScript Vue locations, shadowing, mutation/boundary exclusions, generated documentation, and preset selection. Built CLI probes verified explicit filtering within Strict, Strict alone, and unchanged Recommended behavior, including the diagnostic code, documentation URL, and source line.

Run this rule through the CLI Surface:

```sh
vite-doctor . --extends auto,vite-doctor/typescript/strict --rules typescript/evidence/no-widen-then-assert
```

Inspired by [anti-slop at c44ef22](https://github.com/dmmulroy/anti-slop/blob/c44ef22ca116d0ba62a3ff663a0bd13a3f3fa40b/src/rules/no-widen-then-assert.ts). Doctor-native implementation; no Oxlint plugin dependency is added.

Independent branch from `main`; no other anti-slop PR is required.
