### PR TITLE
feat: diagnose reducer accumulator copies

### DIFF
--- a/.changeset/anti-slop-reduce-copy.md
+++ b/.changeset/anti-slop-reduce-copy.md
@@ -1,0 +1,5 @@
+---
+"vite-doctor": minor
+---
+
+Add typescript/performance/no-reduce-accumulator-copy to the TypeScript Strict Preset with Diagnostic Code TS0010. Detect repeated accumulator copies in inline reduce and reduceRight callbacks.

--- a/docs/app/utils/rule-catalog.test.ts
+++ b/docs/app/utils/rule-catalog.test.ts
@@ -1,3 +1,4 @@
+import { typescriptRulePack } from "../../../src/rule-packs/typescript/index.js";
 import { nextTick, ref } from "vue";
 import { expect, test } from "vite-plus/test";
 import {
@@ -77,7 +78,9 @@ test("rule source exposes canonical docs paths and framework counts", () => {
   expect(reports.all.catalogVersion).toBe(1);
   expect(reports.all.rules.length).toBeGreaterThan(0);
   expect(reports.all.rules.every((rule) => rule.docsPath?.startsWith("/"))).toBe(true);
-  expect(reports.typescript.rules).toHaveLength(8);
+  expect(reports.typescript.rules.map((rule) => rule.id).sort()).toEqual(
+    typescriptRulePack.rules.map((rule) => rule.meta.id).sort(),
+  );
   expect(reports.nuxt.rules.length).toBe(
     reports.vue.rules.length +
       reports.nitro.rules.length +

--- a/src/rule-packs/typescript/diagnostics.ts
+++ b/src/rule-packs/typescript/diagnostics.ts
@@ -15,6 +15,7 @@ export const typescriptDiagnosticRegistry = defineDoctorDiagnostics([
     code: "TS0008",
     ruleId: "typescript/strict/require-safety-comment-for-type-assertion",
   },
+  { code: "TS0010", ruleId: "typescript/performance/no-reduce-accumulator-copy" },
 ]);
 
 export const diagnostics = typescriptDiagnosticRegistry.diagnostics;

--- a/src/rule-packs/typescript/rules/index.ts
+++ b/src/rule-packs/typescript/rules/index.ts
@@ -1,3 +1,4 @@
+export { noReduceAccumulatorCopy } from "./no-reduce-accumulator-copy.js";
 export { noCallerChosenResultType } from "./no-caller-chosen-result-type.js";
 export { noChainedTypeAssertions } from "./no-chained-type-assertions.js";
 export { noConditionalEmptyObjectSpread } from "./no-conditional-empty-object-spread.js";
@@ -17,9 +18,12 @@ import { noUnknownTypeAliases } from "./no-unknown-type-aliases.js";
 import { noUnvalidatedDeserialization } from "./no-unvalidated-deserialization.js";
 import { requireSafetyCommentForTypeAssertion } from "./require-safety-comment-for-type-assertion.js";
 
+import { noReduceAccumulatorCopy } from "./no-reduce-accumulator-copy.js";
+
 const recommendedRules = [noChainedTypeAssertions, noUnvalidatedDeserialization];
 
 const strictRules = [
+  noReduceAccumulatorCopy,
   noCallerChosenResultType,
   ...recommendedRules,
   noObjectParameters,

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -1,0 +1,272 @@
+import { getNodeVisitorKeys } from "../../../core/internal/visitor-keys.js";
+import { parameterType, type AnyNode } from "./shared.js";
+
+type Binding = {
+  node: AnyNode;
+  kind: string;
+  annotation?: AnyNode;
+  init?: AnyNode;
+  written: boolean;
+  owner: AnyNode;
+};
+type Scope = { parent?: Scope; owner: AnyNode; bindings: Map<string, Binding[]> };
+
+export function expression(node: AnyNode): AnyNode {
+  while (
+    node &&
+    [
+      "ParenthesizedExpression",
+      "ChainExpression",
+      "TSSatisfiesExpression",
+      "TSNonNullExpression",
+    ].includes(node.type)
+  )
+    node = node.expression;
+  return node;
+}
+
+export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | null {
+  node = expression(node);
+  if (node?.type !== "MemberExpression" || node.optional) return null;
+  const name =
+    !node.computed && node.property?.type === "Identifier"
+      ? node.property.name
+      : node.property?.type === "Literal"
+        ? node.property.value
+        : null;
+  return typeof name === "string" ? { object: expression(node.object), name } : null;
+}
+
+export function createLocalEvidence(program: AnyNode) {
+  const scopes = new WeakMap<object, Scope>();
+  const writes: AnyNode[] = [];
+  const root: Scope = { owner: program, bindings: new Map() };
+  function bind(pattern: AnyNode, scope: Scope, info: Omit<Binding, "node" | "written" | "owner">) {
+    if (!pattern) return;
+    if (pattern.type === "Identifier") {
+      const bindings = scope.bindings.get(pattern.name) ?? [];
+      bindings.push({
+        ...info,
+        annotation: pattern.typeAnnotation?.typeAnnotation ?? info.annotation,
+        node: pattern,
+        written: false,
+        owner: scope.owner,
+      });
+      scope.bindings.set(pattern.name, bindings);
+    } else if (pattern.type === "AssignmentPattern") bind(pattern.left, scope, { kind: info.kind });
+    else if (pattern.type === "RestElement" || pattern.type === "TSParameterProperty")
+      bind(pattern.argument ?? pattern.parameter, scope, { kind: info.kind });
+    else if (pattern.type === "ArrayPattern")
+      for (const item of pattern.elements) bind(item, scope, { kind: info.kind });
+    else if (pattern.type === "ObjectPattern")
+      for (const item of pattern.properties)
+        bind(item.value ?? item.argument, scope, { kind: info.kind });
+  }
+  function collect(node: AnyNode, outer: Scope) {
+    if (!node?.type) return;
+    if (
+      [
+        "FunctionDeclaration",
+        "ClassDeclaration",
+        "TSTypeAliasDeclaration",
+        "TSInterfaceDeclaration",
+        "TSEnumDeclaration",
+        "TSModuleDeclaration",
+        "TSImportEqualsDeclaration",
+      ].includes(node.type)
+    )
+      bind(node.id, outer, { kind: "other" });
+    if (
+      ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
+    )
+      bind(node.local, outer, { kind: "other" });
+    const isFunction = [
+      "FunctionDeclaration",
+      "FunctionExpression",
+      "ArrowFunctionExpression",
+    ].includes(node.type);
+    const scoped =
+      isFunction ||
+      [
+        "BlockStatement",
+        "StaticBlock",
+        "ForStatement",
+        "ForOfStatement",
+        "ForInStatement",
+        "SwitchStatement",
+        "CatchClause",
+        "ClassExpression",
+        "TSModuleBlock",
+      ].includes(node.type) ||
+      node.typeParameters?.params?.length;
+    const scope = scoped
+      ? {
+          parent: outer,
+          owner: isFunction ? node : outer.owner,
+          bindings: new Map<string, Binding[]>(),
+        }
+      : outer;
+    if (isFunction) {
+      if (node.type === "FunctionExpression") bind(node.id, scope, { kind: "other" });
+      for (const parameter of node.params)
+        bind(parameter, scope, { kind: "parameter", annotation: parameterType(parameter) });
+    }
+    if (node.type === "ClassExpression") bind(node.id, scope, { kind: "other" });
+    if (node.type === "CatchClause") bind(node.param, scope, { kind: "other" });
+    for (const parameter of node.typeParameters?.params ?? [])
+      bind(parameter.name, scope, { kind: "other" });
+    scopes.set(node, scope);
+    if (node.type === "VariableDeclaration") {
+      let target = scope;
+      if (node.kind === "var")
+        while (target.parent && target.parent.owner === target.owner) target = target.parent;
+      for (const declaration of node.declarations)
+        bind(declaration.id, target, { kind: node.kind, init: declaration.init });
+    }
+    if (node.type === "AssignmentExpression") writes.push(node.left);
+    if (node.type === "UpdateExpression") writes.push(node.argument);
+    if (
+      ["ForOfStatement", "ForInStatement"].includes(node.type) &&
+      node.left?.type !== "VariableDeclaration"
+    )
+      writes.push(node.left);
+    for (const key of getNodeVisitorKeys(node)) {
+      const value = node[key];
+      for (const child of Array.isArray(value) ? value : [value]) collect(child, scope);
+    }
+  }
+  collect(program, root);
+  function binding(node: AnyNode): Binding | null {
+    node = expression(node);
+    if (node?.type !== "Identifier") return null;
+    for (let scope = scopes.get(node); scope; scope = scope.parent) {
+      const found = scope.bindings.get(node.name);
+      if (found)
+        return found.length === 1 ? found[0]! : { ...found[0]!, kind: "ambiguous", written: true };
+    }
+    return null;
+  }
+  function markWrite(node: AnyNode) {
+    if (!node) return;
+    if (node.type === "Identifier") {
+      const target = binding(node);
+      if (target) target.written = true;
+    } else if (node.type === "AssignmentPattern") markWrite(node.left);
+    else if (node.type === "RestElement") markWrite(node.argument);
+    else if (node.type === "ArrayPattern") for (const item of node.elements) markWrite(item);
+    else if (node.type === "ObjectPattern")
+      for (const item of node.properties) markWrite(item.value ?? item.argument);
+  }
+  for (const write of writes) markWrite(write);
+  function globalType(node: AnyNode, name: string): boolean {
+    if (
+      node?.type !== "TSTypeReference" ||
+      node.typeName?.type !== "Identifier" ||
+      node.typeName.name !== name
+    )
+      return false;
+    return !binding(node.typeName);
+  }
+  function broadType(node: AnyNode): boolean {
+    if (!node) return false;
+    if (["TSUnknownKeyword", "TSAnyKeyword", "TSObjectKeyword"].includes(node.type)) return true;
+    if (node.type === "TSParenthesizedType") return broadType(node.typeAnnotation);
+    if (node.type === "TSUnionType") return node.types.some((item: AnyNode) => broadType(item));
+    if (node.type === "TSTypeLiteral") return !node.members.length;
+    if (globalType(node, "Readonly")) return broadType(node.typeArguments?.params?.[0]);
+    if (!globalType(node, "Record")) return false;
+    const [key, value] = node.typeArguments?.params ?? [];
+    return (
+      ["TSStringKeyword", "TSNumberKeyword", "TSSymbolKeyword"].includes(key?.type) &&
+      broadType(value)
+    );
+  }
+  function arrayType(node: AnyNode): boolean {
+    if (node?.type === "TSArrayType" || node?.type === "TSTupleType") return true;
+    if (node?.type === "TSTypeOperator" && node.operator === "readonly")
+      return arrayType(node.typeAnnotation);
+    return globalType(node, "Array") || globalType(node, "ReadonlyArray");
+  }
+  function isArray(node: AnyNode, seen = new Set<Binding>()): boolean {
+    node = expression(node);
+    if (!node) return false;
+    if (node.type === "ArrayExpression") return true;
+    if (node.type === "Identifier") {
+      const target = binding(node);
+      if (!target || target.written || seen.has(target)) return false;
+      if (arrayType(target.annotation)) return true;
+      if (
+        target.annotation ||
+        target.kind !== "const" ||
+        !target.init ||
+        target.node.start >= node.start
+      )
+        return false;
+      return isArray(target.init, new Set([...seen, target]));
+    }
+    if (node.type === "CallExpression" && !node.optional) {
+      const method = arrayMethod(node.callee);
+      return (
+        !!method &&
+        [
+          "filter",
+          "map",
+          "flatMap",
+          "slice",
+          "concat",
+          "toSorted",
+          "toReversed",
+          "toSpliced",
+          "with",
+        ].includes(method.name) &&
+        isArray(method.object, seen)
+      );
+    }
+    return false;
+  }
+  function known(node: AnyNode, seen = new Set<Binding>()): boolean {
+    node = expression(node);
+    if (!node) return false;
+    if (
+      [
+        "Literal",
+        "ObjectExpression",
+        "ArrayExpression",
+        "ArrowFunctionExpression",
+        "FunctionExpression",
+      ].includes(node.type)
+    )
+      return true;
+    if (node.type !== "Identifier") return false;
+    const target = binding(node);
+    if (!target || target.written || seen.has(target)) return false;
+    if (target.annotation)
+      return (
+        [
+          "TSStringKeyword",
+          "TSNumberKeyword",
+          "TSBooleanKeyword",
+          "TSBigIntKeyword",
+          "TSSymbolKeyword",
+          "TSLiteralType",
+          "TSArrayType",
+          "TSTupleType",
+          "TSFunctionType",
+        ].includes(target.annotation.type) ||
+        (target.annotation.type === "TSTypeLiteral" && target.annotation.members.length > 0)
+      );
+    return (
+      target.kind === "const" &&
+      target.node.start < node.start &&
+      known(target.init, new Set([...seen, target]))
+    );
+  }
+  return {
+    binding,
+    broadType,
+    globalType,
+    isArray,
+    known,
+    owner: (node: AnyNode) => scopes.get(node)?.owner,
+  };
+}

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -9,7 +9,12 @@ type Binding = {
   written: boolean;
   owner: AnyNode;
 };
-type Scope = { parent?: Scope; owner: AnyNode; bindings: Map<string, Binding[]> };
+type Scope = {
+  parent?: Scope;
+  owner: AnyNode;
+  bindings: Map<string, Binding[]>;
+  types: Set<string>;
+};
 
 export function expression(node: AnyNode): AnyNode {
   while (
@@ -40,7 +45,7 @@ export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | 
 export function createLocalEvidence(program: AnyNode) {
   const scopes = new WeakMap<object, Scope>();
   const writes: AnyNode[] = [];
-  const root: Scope = { owner: program, bindings: new Map() };
+  const root: Scope = { owner: program, bindings: new Map(), types: new Set() };
   function bind(pattern: AnyNode, scope: Scope, info: Omit<Binding, "node" | "written" | "owner">) {
     if (!pattern) return;
     if (pattern.type === "Identifier") {
@@ -63,7 +68,30 @@ export function createLocalEvidence(program: AnyNode) {
         bind(item.value ?? item.argument, scope, { kind: info.kind });
   }
   function collect(node: AnyNode, outer: Scope) {
-    if (!node?.type || node.importKind === "type") return;
+    if (!node?.type) return;
+    if (
+      [
+        "TSTypeAliasDeclaration",
+        "TSInterfaceDeclaration",
+        "ClassDeclaration",
+        "TSEnumDeclaration",
+        "TSModuleDeclaration",
+        "TSImportEqualsDeclaration",
+      ].includes(node.type) &&
+      node.id?.name
+    )
+      outer.types.add(node.id.name);
+    if (node.type === "TSImportEqualsDeclaration" && node.importKind === "type") return;
+    if (node.type === "ImportDeclaration" && node.importKind === "type") {
+      for (const specifier of node.specifiers) outer.types.add(specifier.local.name);
+      return;
+    }
+    if (
+      ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
+    ) {
+      outer.types.add(node.local.name);
+      if (node.importKind === "type") return;
+    }
     if (
       [
         "FunctionDeclaration",
@@ -102,8 +130,12 @@ export function createLocalEvidence(program: AnyNode) {
           parent: outer,
           owner: isFunction ? node : outer.owner,
           bindings: new Map<string, Binding[]>(),
+          types: new Set<string>(),
         }
       : outer;
+    for (const parameter of node.typeParameters?.params ?? [])
+      scope.types.add(parameter.name?.name ?? parameter.name);
+    if (node.type === "ClassExpression" && node.id?.name) scope.types.add(node.id.name);
     if (isFunction) {
       if (node.type === "FunctionExpression") bind(node.id, scope, { kind: "other" });
       for (const parameter of node.params)
@@ -161,7 +193,9 @@ export function createLocalEvidence(program: AnyNode) {
       node.typeName.name !== name
     )
       return false;
-    return !binding(node.typeName);
+    for (let scope = scopes.get(node); scope; scope = scope.parent)
+      if (scope.types.has(name)) return false;
+    return true;
   }
   function broadType(node: AnyNode): boolean {
     if (!node) return false;

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -63,13 +63,11 @@ export function createLocalEvidence(program: AnyNode) {
         bind(item.value ?? item.argument, scope, { kind: info.kind });
   }
   function collect(node: AnyNode, outer: Scope) {
-    if (!node?.type) return;
+    if (!node?.type || node.importKind === "type") return;
     if (
       [
         "FunctionDeclaration",
         "ClassDeclaration",
-        "TSTypeAliasDeclaration",
-        "TSInterfaceDeclaration",
         "TSEnumDeclaration",
         "TSModuleDeclaration",
         "TSImportEqualsDeclaration",
@@ -113,8 +111,6 @@ export function createLocalEvidence(program: AnyNode) {
     }
     if (node.type === "ClassExpression") bind(node.id, scope, { kind: "other" });
     if (node.type === "CatchClause") bind(node.param, scope, { kind: "other" });
-    for (const parameter of node.typeParameters?.params ?? [])
-      bind(parameter.name, scope, { kind: "other" });
     scopes.set(node, scope);
     if (node.type === "VariableDeclaration") {
       let target = scope;
@@ -150,7 +146,7 @@ export function createLocalEvidence(program: AnyNode) {
     if (!node) return;
     if (node.type === "Identifier") {
       const target = binding(node);
-      if (target) target.written = true;
+      if (target && target.owner === scopes.get(node)?.owner) target.written = true;
     } else if (node.type === "AssignmentPattern") markWrite(node.left);
     else if (node.type === "RestElement") markWrite(node.argument);
     else if (node.type === "ArrayPattern") for (const item of node.elements) markWrite(item);

--- a/src/rule-packs/typescript/rules/no-reduce-accumulator-copy.ts
+++ b/src/rule-packs/typescript/rules/no-reduce-accumulator-copy.ts
@@ -1,0 +1,99 @@
+import { createRule } from "../../../core/index.js";
+import { parentOf, isTypeScriptSource, report, type AnyNode } from "./shared.js";
+import { arrayMethod, createLocalEvidence, expression } from "./local-evidence.js";
+
+const ruleId = "typescript/performance/no-reduce-accumulator-copy";
+
+export const noReduceAccumulatorCopy = createRule({
+  meta: {
+    id: "typescript/performance/no-reduce-accumulator-copy",
+    title: "Avoid copying growing reducer accumulators",
+    description: "Detect repeated accumulator copies in inline reduce and reduceRight callbacks.",
+    why: "Copying accumulated state on every iteration can cause quadratic work as the accumulator grows. This rule covers Object.assign, Array.from, and array copy methods with local array evidence. It does not prove receiver types or accumulator growth; bounded copies may be intentional. Spreads and named callbacks are outside its scope.",
+    recommendedReplacement:
+      "Use a fresh, locally owned accumulator and update it in place after reviewing ownership. Do not mutate shared initial state.",
+    examples: [
+      {
+        title: "Avoid copying growing reducer accumulators",
+        language: "ts",
+        invalid: "items.reduce((acc, item) => acc.concat([item]), [])",
+        valid: "items.reduce((acc, item) => { acc.push(item); return acc }, [])",
+      },
+    ],
+    category: "performance",
+    severity: "warn",
+    fixable: "structural-review",
+    docsUrl:
+      "https://github.com/dmmulroy/anti-slop/tree/c44ef22ca116d0ba62a3ff663a0bd13a3f3fa40b#rules",
+    requires: { script: true },
+    aiGeneratedCodeRisk: "high",
+  },
+  create(ctx) {
+    if (!isTypeScriptSource(ctx)) return;
+    let evidence: ReturnType<typeof createLocalEvidence>;
+    function references(
+      node: AnyNode,
+      accumulator: unknown,
+      owner: AnyNode,
+      seen = new Set<unknown>(),
+    ): boolean {
+      const target = evidence.binding(expression(node));
+      if (!target || target.written || seen.has(target)) return false;
+      if (target === accumulator) return true;
+      if (target.kind !== "const" || target.owner !== owner || target.node.start >= node.start)
+        return false;
+      seen.add(target);
+      return references(target.init, accumulator, owner, seen);
+    }
+    return {
+      ScriptNode(node: AnyNode) {
+        if (node.type === "Program") {
+          evidence = createLocalEvidence(node);
+          return;
+        }
+        if (node.type !== "CallExpression" || node.optional) return;
+        const method = arrayMethod(node.callee);
+        if (!method) return;
+        const callback = evidence.owner(node);
+        if (!["ArrowFunctionExpression", "FunctionExpression"].includes(callback?.type)) return;
+        const reducer = parentOf(callback);
+        if (
+          reducer?.type !== "CallExpression" ||
+          reducer.optional ||
+          reducer.arguments.length !== 2 ||
+          reducer.arguments[0] !== callback
+        )
+          return;
+        const reducerMethod = arrayMethod(reducer.callee);
+        if (!reducerMethod || !["reduce", "reduceRight"].includes(reducerMethod.name)) return;
+        const parameter = callback.params[0];
+        if (parameter?.type !== "Identifier") return;
+        const accumulator = evidence.binding(parameter);
+        const isAccumulator = (value: AnyNode) => references(value, accumulator, callback);
+        const globalOwner = (name: string) =>
+          method.object?.type === "Identifier" &&
+          method.object.name === name &&
+          !evidence.binding(method.object);
+        let copies = false;
+        if (method.name === "assign" && globalOwner("Object"))
+          copies =
+            expression(node.arguments[0])?.type === "ObjectExpression" &&
+            node.arguments.slice(1).some(isAccumulator);
+        else if (method.name === "from" && globalOwner("Array"))
+          copies = isAccumulator(node.arguments[0]);
+        else if (
+          ["concat", "slice", "toSpliced", "toSorted", "toReversed", "with"].includes(method.name)
+        )
+          copies = evidence.isArray(reducer.arguments[1]) && isAccumulator(method.object);
+        if (copies)
+          report(
+            ctx,
+            node,
+            ruleId,
+            "This reducer copies accumulated state on every iteration; growing copies can cause quadratic work.",
+            "Update a fresh, locally owned accumulator in place after reviewing ownership. Preserve shared or externally owned initial state.",
+          );
+      },
+    };
+  },
+});

--- a/src/rule-packs/typescript/rules/no-reduce-accumulator-copy.ts
+++ b/src/rule-packs/typescript/rules/no-reduce-accumulator-copy.ts
@@ -66,7 +66,9 @@ export const noReduceAccumulatorCopy = createRule({
           return;
         const reducerMethod = arrayMethod(reducer.callee);
         if (!reducerMethod || !["reduce", "reduceRight"].includes(reducerMethod.name)) return;
-        const parameter = callback.params[0];
+        const firstParameter = callback.params[0];
+        const parameter =
+          firstParameter?.type === "AssignmentPattern" ? firstParameter.left : firstParameter;
         if (parameter?.type !== "Identifier") return;
         const accumulator = evidence.binding(parameter);
         const isAccumulator = (value: AnyNode) => references(value, accumulator, callback);

--- a/tests/rule-packs/typescript/reduce-copy.test.ts
+++ b/tests/rule-packs/typescript/reduce-copy.test.ts
@@ -49,6 +49,46 @@ const cases: [string, string, number][] = [
     'import { Array } from "example"; items.reduce((acc, item) => Array.from(acc), [])',
     0,
   ],
+  [
+    "local array type",
+    "type Array = string; const initial: Array = ''; items.reduce((acc, item) => acc.slice(), initial)",
+    0,
+  ],
+  [
+    "local readonly array interface",
+    "interface ReadonlyArray { slice(): string }; const initial: ReadonlyArray = value; items.reduce((acc, item) => acc.slice(), initial)",
+    0,
+  ],
+  [
+    "array type parameter",
+    "function f<Array>(initial: Array) { return items.reduce((acc, item) => acc.slice(), initial) }",
+    0,
+  ],
+  [
+    "array type import",
+    'import type { Array } from "example"; const initial: Array = value; items.reduce((acc, item) => acc.slice(), initial)',
+    0,
+  ],
+  [
+    "inline array type import",
+    'import { type Array } from "example"; const initial: Array = value; items.reduce((acc, item) => acc.slice(), initial)',
+    0,
+  ],
+  [
+    "global array type",
+    "const initial: Array<number> = value; items.reduce((acc, item) => acc.slice(), initial)",
+    1,
+  ],
+  [
+    "value-only array name",
+    "const Array = custom; const initial: Array<number> = value; items.reduce((acc, item) => acc.slice(), initial)",
+    1,
+  ],
+  [
+    "type scope boundary",
+    "function f<Array>() {} const initial: Array<number> = value; items.reduce((acc, item) => acc.slice(), initial)",
+    1,
+  ],
   ["concat", "items.reduce((acc, item) => acc.concat([item]), [])", 1],
   [
     "slice alias",

--- a/tests/rule-packs/typescript/reduce-copy.test.ts
+++ b/tests/rule-packs/typescript/reduce-copy.test.ts
@@ -7,6 +7,48 @@ import {
 import { getRuleDocuments, getDiagnosticDocuments } from "../../../docs/rules/source.js";
 
 const cases: [string, string, number][] = [
+  ["default accumulator", "items.reduce((acc = [], item) => acc.concat(item), [])", 1],
+  [
+    "default reassigned",
+    "items.reduce((acc = [], item) => { acc = item; return acc.slice() }, [])",
+    0,
+  ],
+  [
+    "nested write",
+    "items.reduce((acc, item) => { function unused() { acc = item } return acc.slice() }, [])",
+    1,
+  ],
+  [
+    "nested destructuring write",
+    "items.reduce((acc, item) => { const unused = () => { [acc] = item }; return acc.slice() }, [])",
+    1,
+  ],
+  [
+    "type parameter Object",
+    "function f<Object>() { return items.reduce((acc, item) => Object.assign({}, acc, item), {}) }",
+    1,
+  ],
+  ["type alias Array", "type Array = unknown; items.reduce((acc, item) => Array.from(acc), [])", 1],
+  [
+    "interface Object",
+    "interface Object {}; items.reduce((acc, item) => Object.assign({}, acc, item), {})",
+    1,
+  ],
+  [
+    "type import Array",
+    'import type { Array } from "example"; items.reduce((acc, item) => Array.from(acc), [])',
+    1,
+  ],
+  [
+    "inline type import Object",
+    'import { type Object } from "example"; items.reduce((acc, item) => Object.assign({}, acc, item), {})',
+    1,
+  ],
+  [
+    "value import Array",
+    'import { Array } from "example"; items.reduce((acc, item) => Array.from(acc), [])',
+    0,
+  ],
   ["concat", "items.reduce((acc, item) => acc.concat([item]), [])", 1],
   [
     "slice alias",

--- a/tests/rule-packs/typescript/reduce-copy.test.ts
+++ b/tests/rule-packs/typescript/reduce-copy.test.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "vite-plus/test";
+import { runProjectFixture } from "../../../src/core/testkit.js";
+import {
+  noReduceAccumulatorCopy,
+  typescriptRulePack,
+} from "../../../src/rule-packs/typescript/index.js";
+import { getRuleDocuments, getDiagnosticDocuments } from "../../../docs/rules/source.js";
+
+const cases: [string, string, number][] = [
+  ["concat", "items.reduce((acc, item) => acc.concat([item]), [])", 1],
+  [
+    "slice alias",
+    "items.reduce((acc, item) => { const alias = acc; const next = alias.slice(); next.push(item); return next }, [])",
+    1,
+  ],
+  [
+    "Object.assign",
+    "items.reduce((acc, item) => Object.assign({}, acc, { [item.id]: item }), {})",
+    1,
+  ],
+  ["Array.from", "items.reduce((acc, item) => Array.from(acc), [])", 1],
+  ["reduceRight", "items.reduceRight((acc, item, index) => acc.toSpliced(index, 0, item), [])", 1],
+  [
+    "array initializer alias",
+    "const initial = []; items.reduce((acc, item) => acc.concat([item]), initial)",
+    1,
+  ],
+  ["fresh mutation", "items.reduce((acc, item) => { acc.push(item); return acc }, [])", 0],
+  ["in place assign", "items.reduce((acc, item) => Object.assign(acc, item), {})", 0],
+  ["string concat", "items.reduce((acc, item) => acc.concat(item), '')", 0],
+  ["unknown initial", "items.reduce((acc, item) => acc.slice(), initial)", 0],
+  [
+    "shadowed Object",
+    "function f(Object) { return items.reduce((acc, item) => Object.assign({}, acc, item), {}) }",
+    0,
+  ],
+  [
+    "shadowed Array",
+    "function f(Array) { return items.reduce((acc, item) => Array.from(acc), []) }",
+    0,
+  ],
+  [
+    "nested callback",
+    "items.reduce((acc, item) => { function copy() { return acc.slice() } return acc }, [])",
+    0,
+  ],
+  [
+    "named callback",
+    "const callback = (acc, item) => acc.concat(item); items.reduce(callback, [])",
+    0,
+  ],
+  ["input copies", "items.reduce((acc, item) => { const copy = item.slice(); return acc }, [])", 0],
+  [
+    "reassigned accumulator",
+    "items.reduce((acc, item) => { acc = item; return acc.slice() }, [])",
+    0,
+  ],
+  [
+    "shadowed alias",
+    "items.reduce((acc, item) => { const alias = acc; { const alias = item; alias.slice() } return acc }, [])",
+    0,
+  ],
+  ["no initial", "items.reduce((acc, item) => acc.slice())", 0],
+];
+
+test.each(cases)("checks %s", async (_name, source, expected) => {
+  const result = await runProjectFixture({
+    framework: "vite",
+    rules: [noReduceAccumulatorCopy],
+    files: { "index.ts": source },
+  });
+  expect(result.diagnostics.map((item) => item.code)).toEqual(Array(expected).fill("TS0010"));
+});
+
+test("exports an opt-in rule with generated rule and diagnostic documentation", () => {
+  expect(typescriptRulePack.presets.strict).toContain(noReduceAccumulatorCopy.meta.id);
+  expect(typescriptRulePack.presets.recommended).not.toContain(noReduceAccumulatorCopy.meta.id);
+  expect(
+    getRuleDocuments().find((rule) => rule.id === noReduceAccumulatorCopy.meta.id)?.examples.length,
+  ).toBeGreaterThan(0);
+  expect(getDiagnosticDocuments().find((diagnostic) => diagnostic.code === "TS0010")?.ruleId).toBe(
+    noReduceAccumulatorCopy.meta.id,
+  );
+});
+
+test("reports TypeScript Vue scripts with source locations", async () => {
+  const result = await runProjectFixture({
+    rules: [noReduceAccumulatorCopy],
+    files: {
+      "App.vue":
+        '<template><p>Example</p></template>\n<script setup lang="ts">\n' +
+        cases[0]![1] +
+        "\n</script>",
+    },
+  });
+  expect(result.diagnostics.map((item) => item.code)).toEqual(["TS0010"]);
+  expect(result.diagnostics[0]?.range?.line).toBe(3);
+});
+
+test("leaves JavaScript-only sources outside the TypeScript Rule Pack", async () => {
+  const result = await runProjectFixture({
+    framework: "vite",
+    rules: [noReduceAccumulatorCopy],
+    files: {
+      "index.js":
+        "const values = [1]; values.filter(keep).map(transform); values.reduce((acc, item) => acc.concat(item), [])",
+    },
+  });
+  expect(result.diagnostics).toHaveLength(0);
+});


### PR DESCRIPTION
Repeated copies such as `items.reduce((acc, item) => acc.concat([item]), [])` can cause quadratic work as the accumulator grows. Add an optional Strict Preset diagnostic for non-spread accumulator copies.

Covers inline reduce/reduceRight callbacks with an initial value, immutable accumulator aliases, global Object.assign/Array.from, and array copy methods when the initial value has local array evidence. Shadowed globals, reassigned accumulators, input-item copies, string concatenation, named callbacks, and nested helper functions are excluded. Method names are syntactic evidence; the rule does not prove the receiver is an array or that the accumulator grows. Spreads remain outside this rule. Remediation requires reviewing accumulator ownership; no mutation autofix is provided.

Registers Diagnostic Code `TS0010`, public Rule Pack exports, rule metadata for generated Rule Catalog and Diagnostic Reference pages, and a changeset. Recommended Preset behavior remains unchanged; JavaScript-only sources stay outside the TypeScript Rule Pack.

The catalog test now compares documented rule IDs with registered rule IDs instead of fixing the TypeScript rule count at eight. The local-evidence helper is identical across the four new-rule PRs so it can be shared when they merge; each branch includes it and builds independently.

Validation: formatting, lint, declaration build, and all 417 tests passed across the runtime and documentation suites. The first full run exposed the obsolete catalog count; the corrected documentation suite passed on rerun. Tests include TypeScript Vue locations, shadowing, mutation/boundary exclusions, generated documentation, and preset selection. Built CLI probes verified explicit filtering within Strict, Strict alone, and unchanged Recommended behavior, including the diagnostic code, documentation URL, and source line.

Run this rule through the CLI Surface:

```sh
vite-doctor . --extends auto,vite-doctor/typescript/strict --rules typescript/performance/no-reduce-accumulator-copy
```

Inspired by [anti-slop at c44ef22](https://github.com/dmmulroy/anti-slop/blob/c44ef22ca116d0ba62a3ff663a0bd13a3f3fa40b/src/rules/no-reduce-accumulator-copy.ts). Doctor-native implementation; no Oxlint plugin dependency is added.

Independent branch from `main`; no other anti-slop PR is required.
