### PR TITLE
feat: add optional adjacent array-pass diagnostic

### DIFF
--- a/.changeset/anti-slop-array-filter-map.md
+++ b/.changeset/anti-slop-array-filter-map.md
@@ -1,0 +1,5 @@
+---
+"vite-doctor": minor
+---
+
+Add typescript/performance/no-array-filter-map to the TypeScript Strict Preset with Diagnostic Code TS0012. Detect adjacent filter/map or map/filter passes on locally evidenced arrays.

--- a/docs/app/utils/rule-catalog.test.ts
+++ b/docs/app/utils/rule-catalog.test.ts
@@ -1,3 +1,4 @@
+import { typescriptRulePack } from "../../../src/rule-packs/typescript/index.js";
 import { nextTick, ref } from "vue";
 import { expect, test } from "vite-plus/test";
 import {
@@ -77,7 +78,9 @@ test("rule source exposes canonical docs paths and framework counts", () => {
   expect(reports.all.catalogVersion).toBe(1);
   expect(reports.all.rules.length).toBeGreaterThan(0);
   expect(reports.all.rules.every((rule) => rule.docsPath?.startsWith("/"))).toBe(true);
-  expect(reports.typescript.rules).toHaveLength(8);
+  expect(reports.typescript.rules.map((rule) => rule.id).sort()).toEqual(
+    typescriptRulePack.rules.map((rule) => rule.meta.id).sort(),
+  );
   expect(reports.nuxt.rules.length).toBe(
     reports.vue.rules.length +
       reports.nitro.rules.length +

--- a/src/core/diagnostic-code-map.ts
+++ b/src/core/diagnostic-code-map.ts
@@ -82,6 +82,7 @@ export const allDoctorDiagnosticRegistry = defineDoctorDiagnostics([
     code: "TS0008",
     ruleId: "typescript/strict/require-safety-comment-for-type-assertion",
   },
+  { code: "TS0012", ruleId: "typescript/performance/no-array-filter-map" },
   { code: "NITRO0001", ruleId: "nitro/context/no-navigateto-in-nitro" },
   { code: "NITRO0002", ruleId: "nitro/context/no-usenuxtapp-in-nitro" },
   { code: "NITRO0003", ruleId: "nitro/request/prefer-assert-method" },

--- a/src/rule-packs/typescript/diagnostics.ts
+++ b/src/rule-packs/typescript/diagnostics.ts
@@ -15,6 +15,7 @@ export const typescriptDiagnosticRegistry = defineDoctorDiagnostics([
     code: "TS0008",
     ruleId: "typescript/strict/require-safety-comment-for-type-assertion",
   },
+  { code: "TS0012", ruleId: "typescript/performance/no-array-filter-map" },
 ]);
 
 export const diagnostics = typescriptDiagnosticRegistry.diagnostics;

--- a/src/rule-packs/typescript/rules/index.ts
+++ b/src/rule-packs/typescript/rules/index.ts
@@ -1,3 +1,4 @@
+export { noArrayFilterMap } from "./no-array-filter-map.js";
 export { noCallerChosenResultType } from "./no-caller-chosen-result-type.js";
 export { noChainedTypeAssertions } from "./no-chained-type-assertions.js";
 export { noConditionalEmptyObjectSpread } from "./no-conditional-empty-object-spread.js";
@@ -17,9 +18,12 @@ import { noUnknownTypeAliases } from "./no-unknown-type-aliases.js";
 import { noUnvalidatedDeserialization } from "./no-unvalidated-deserialization.js";
 import { requireSafetyCommentForTypeAssertion } from "./require-safety-comment-for-type-assertion.js";
 
+import { noArrayFilterMap } from "./no-array-filter-map.js";
+
 const recommendedRules = [noChainedTypeAssertions, noUnvalidatedDeserialization];
 
 const strictRules = [
+  noArrayFilterMap,
   noCallerChosenResultType,
   ...recommendedRules,
   noObjectParameters,

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -1,0 +1,272 @@
+import { getNodeVisitorKeys } from "../../../core/internal/visitor-keys.js";
+import { parameterType, type AnyNode } from "./shared.js";
+
+type Binding = {
+  node: AnyNode;
+  kind: string;
+  annotation?: AnyNode;
+  init?: AnyNode;
+  written: boolean;
+  owner: AnyNode;
+};
+type Scope = { parent?: Scope; owner: AnyNode; bindings: Map<string, Binding[]> };
+
+export function expression(node: AnyNode): AnyNode {
+  while (
+    node &&
+    [
+      "ParenthesizedExpression",
+      "ChainExpression",
+      "TSSatisfiesExpression",
+      "TSNonNullExpression",
+    ].includes(node.type)
+  )
+    node = node.expression;
+  return node;
+}
+
+export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | null {
+  node = expression(node);
+  if (node?.type !== "MemberExpression" || node.optional) return null;
+  const name =
+    !node.computed && node.property?.type === "Identifier"
+      ? node.property.name
+      : node.property?.type === "Literal"
+        ? node.property.value
+        : null;
+  return typeof name === "string" ? { object: expression(node.object), name } : null;
+}
+
+export function createLocalEvidence(program: AnyNode) {
+  const scopes = new WeakMap<object, Scope>();
+  const writes: AnyNode[] = [];
+  const root: Scope = { owner: program, bindings: new Map() };
+  function bind(pattern: AnyNode, scope: Scope, info: Omit<Binding, "node" | "written" | "owner">) {
+    if (!pattern) return;
+    if (pattern.type === "Identifier") {
+      const bindings = scope.bindings.get(pattern.name) ?? [];
+      bindings.push({
+        ...info,
+        annotation: pattern.typeAnnotation?.typeAnnotation ?? info.annotation,
+        node: pattern,
+        written: false,
+        owner: scope.owner,
+      });
+      scope.bindings.set(pattern.name, bindings);
+    } else if (pattern.type === "AssignmentPattern") bind(pattern.left, scope, { kind: info.kind });
+    else if (pattern.type === "RestElement" || pattern.type === "TSParameterProperty")
+      bind(pattern.argument ?? pattern.parameter, scope, { kind: info.kind });
+    else if (pattern.type === "ArrayPattern")
+      for (const item of pattern.elements) bind(item, scope, { kind: info.kind });
+    else if (pattern.type === "ObjectPattern")
+      for (const item of pattern.properties)
+        bind(item.value ?? item.argument, scope, { kind: info.kind });
+  }
+  function collect(node: AnyNode, outer: Scope) {
+    if (!node?.type) return;
+    if (
+      [
+        "FunctionDeclaration",
+        "ClassDeclaration",
+        "TSTypeAliasDeclaration",
+        "TSInterfaceDeclaration",
+        "TSEnumDeclaration",
+        "TSModuleDeclaration",
+        "TSImportEqualsDeclaration",
+      ].includes(node.type)
+    )
+      bind(node.id, outer, { kind: "other" });
+    if (
+      ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
+    )
+      bind(node.local, outer, { kind: "other" });
+    const isFunction = [
+      "FunctionDeclaration",
+      "FunctionExpression",
+      "ArrowFunctionExpression",
+    ].includes(node.type);
+    const scoped =
+      isFunction ||
+      [
+        "BlockStatement",
+        "StaticBlock",
+        "ForStatement",
+        "ForOfStatement",
+        "ForInStatement",
+        "SwitchStatement",
+        "CatchClause",
+        "ClassExpression",
+        "TSModuleBlock",
+      ].includes(node.type) ||
+      node.typeParameters?.params?.length;
+    const scope = scoped
+      ? {
+          parent: outer,
+          owner: isFunction ? node : outer.owner,
+          bindings: new Map<string, Binding[]>(),
+        }
+      : outer;
+    if (isFunction) {
+      if (node.type === "FunctionExpression") bind(node.id, scope, { kind: "other" });
+      for (const parameter of node.params)
+        bind(parameter, scope, { kind: "parameter", annotation: parameterType(parameter) });
+    }
+    if (node.type === "ClassExpression") bind(node.id, scope, { kind: "other" });
+    if (node.type === "CatchClause") bind(node.param, scope, { kind: "other" });
+    for (const parameter of node.typeParameters?.params ?? [])
+      bind(parameter.name, scope, { kind: "other" });
+    scopes.set(node, scope);
+    if (node.type === "VariableDeclaration") {
+      let target = scope;
+      if (node.kind === "var")
+        while (target.parent && target.parent.owner === target.owner) target = target.parent;
+      for (const declaration of node.declarations)
+        bind(declaration.id, target, { kind: node.kind, init: declaration.init });
+    }
+    if (node.type === "AssignmentExpression") writes.push(node.left);
+    if (node.type === "UpdateExpression") writes.push(node.argument);
+    if (
+      ["ForOfStatement", "ForInStatement"].includes(node.type) &&
+      node.left?.type !== "VariableDeclaration"
+    )
+      writes.push(node.left);
+    for (const key of getNodeVisitorKeys(node)) {
+      const value = node[key];
+      for (const child of Array.isArray(value) ? value : [value]) collect(child, scope);
+    }
+  }
+  collect(program, root);
+  function binding(node: AnyNode): Binding | null {
+    node = expression(node);
+    if (node?.type !== "Identifier") return null;
+    for (let scope = scopes.get(node); scope; scope = scope.parent) {
+      const found = scope.bindings.get(node.name);
+      if (found)
+        return found.length === 1 ? found[0]! : { ...found[0]!, kind: "ambiguous", written: true };
+    }
+    return null;
+  }
+  function markWrite(node: AnyNode) {
+    if (!node) return;
+    if (node.type === "Identifier") {
+      const target = binding(node);
+      if (target) target.written = true;
+    } else if (node.type === "AssignmentPattern") markWrite(node.left);
+    else if (node.type === "RestElement") markWrite(node.argument);
+    else if (node.type === "ArrayPattern") for (const item of node.elements) markWrite(item);
+    else if (node.type === "ObjectPattern")
+      for (const item of node.properties) markWrite(item.value ?? item.argument);
+  }
+  for (const write of writes) markWrite(write);
+  function globalType(node: AnyNode, name: string): boolean {
+    if (
+      node?.type !== "TSTypeReference" ||
+      node.typeName?.type !== "Identifier" ||
+      node.typeName.name !== name
+    )
+      return false;
+    return !binding(node.typeName);
+  }
+  function broadType(node: AnyNode): boolean {
+    if (!node) return false;
+    if (["TSUnknownKeyword", "TSAnyKeyword", "TSObjectKeyword"].includes(node.type)) return true;
+    if (node.type === "TSParenthesizedType") return broadType(node.typeAnnotation);
+    if (node.type === "TSUnionType") return node.types.some((item: AnyNode) => broadType(item));
+    if (node.type === "TSTypeLiteral") return !node.members.length;
+    if (globalType(node, "Readonly")) return broadType(node.typeArguments?.params?.[0]);
+    if (!globalType(node, "Record")) return false;
+    const [key, value] = node.typeArguments?.params ?? [];
+    return (
+      ["TSStringKeyword", "TSNumberKeyword", "TSSymbolKeyword"].includes(key?.type) &&
+      broadType(value)
+    );
+  }
+  function arrayType(node: AnyNode): boolean {
+    if (node?.type === "TSArrayType" || node?.type === "TSTupleType") return true;
+    if (node?.type === "TSTypeOperator" && node.operator === "readonly")
+      return arrayType(node.typeAnnotation);
+    return globalType(node, "Array") || globalType(node, "ReadonlyArray");
+  }
+  function isArray(node: AnyNode, seen = new Set<Binding>()): boolean {
+    node = expression(node);
+    if (!node) return false;
+    if (node.type === "ArrayExpression") return true;
+    if (node.type === "Identifier") {
+      const target = binding(node);
+      if (!target || target.written || seen.has(target)) return false;
+      if (arrayType(target.annotation)) return true;
+      if (
+        target.annotation ||
+        target.kind !== "const" ||
+        !target.init ||
+        target.node.start >= node.start
+      )
+        return false;
+      return isArray(target.init, new Set([...seen, target]));
+    }
+    if (node.type === "CallExpression" && !node.optional) {
+      const method = arrayMethod(node.callee);
+      return (
+        !!method &&
+        [
+          "filter",
+          "map",
+          "flatMap",
+          "slice",
+          "concat",
+          "toSorted",
+          "toReversed",
+          "toSpliced",
+          "with",
+        ].includes(method.name) &&
+        isArray(method.object, seen)
+      );
+    }
+    return false;
+  }
+  function known(node: AnyNode, seen = new Set<Binding>()): boolean {
+    node = expression(node);
+    if (!node) return false;
+    if (
+      [
+        "Literal",
+        "ObjectExpression",
+        "ArrayExpression",
+        "ArrowFunctionExpression",
+        "FunctionExpression",
+      ].includes(node.type)
+    )
+      return true;
+    if (node.type !== "Identifier") return false;
+    const target = binding(node);
+    if (!target || target.written || seen.has(target)) return false;
+    if (target.annotation)
+      return (
+        [
+          "TSStringKeyword",
+          "TSNumberKeyword",
+          "TSBooleanKeyword",
+          "TSBigIntKeyword",
+          "TSSymbolKeyword",
+          "TSLiteralType",
+          "TSArrayType",
+          "TSTupleType",
+          "TSFunctionType",
+        ].includes(target.annotation.type) ||
+        (target.annotation.type === "TSTypeLiteral" && target.annotation.members.length > 0)
+      );
+    return (
+      target.kind === "const" &&
+      target.node.start < node.start &&
+      known(target.init, new Set([...seen, target]))
+    );
+  }
+  return {
+    binding,
+    broadType,
+    globalType,
+    isArray,
+    known,
+    owner: (node: AnyNode) => scopes.get(node)?.owner,
+  };
+}

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -101,10 +101,11 @@ export function createLocalEvidence(program: AnyNode, { unwrapArrayAssertions = 
       return;
     }
     if (
-      ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
+      ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type) &&
+      node.importKind === "type"
     ) {
       outer.types.add(node.local.name);
-      if (node.importKind === "type") return;
+      return;
     }
     if (
       [

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -46,6 +46,7 @@ export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | 
 export function createLocalEvidence(program: AnyNode) {
   const scopes = new WeakMap<object, Scope>();
   const writes: AnyNode[] = [];
+  const namespaces = new WeakMap<Scope, Map<string, Scope>>();
   const root: Scope = { owner: program, bindings: new Map(), types: new Set() };
   function bind(pattern: AnyNode, scope: Scope, info: Omit<Binding, "node" | "written" | "owner">) {
     if (!pattern) return;
@@ -72,8 +73,12 @@ export function createLocalEvidence(program: AnyNode) {
       for (const item of pattern.properties)
         bind(item.value ?? item.argument, scope, { kind: info.kind });
   }
-  function collect(node: AnyNode, outer: Scope) {
+  function collect(node: AnyNode, outer: Scope, exports?: Scope) {
     if (!node?.type) return;
+    if (node.type === "TSModuleDeclaration" && node.id?.type === "TSQualifiedName") {
+      collect({ ...node, id: node.id.left, body: { ...node, id: node.id.right } }, outer, exports);
+      return;
+    }
     if (
       [
         "TSTypeAliasDeclaration",
@@ -84,7 +89,7 @@ export function createLocalEvidence(program: AnyNode) {
       ].includes(node.type) &&
       node.id?.name
     )
-      outer.types.add(node.id.name);
+      (exports ?? outer).types.add(node.id.name);
     if (node.type === "TSImportEqualsDeclaration" && node.importKind === "type") return;
     if (node.type === "ImportDeclaration" && node.importKind === "type") {
       for (const specifier of node.specifiers) outer.types.add(specifier.local.name);
@@ -110,6 +115,41 @@ export function createLocalEvidence(program: AnyNode) {
       ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
     )
       bind(node.local, outer, { kind: "other" });
+    if (
+      node.type === "TSModuleDeclaration" &&
+      node.id?.name &&
+      ["TSModuleBlock", "TSModuleDeclaration"].includes(node.body?.type)
+    ) {
+      const owner = exports ?? outer;
+      let members = namespaces.get(owner);
+      if (!members) namespaces.set(owner, (members = new Map()));
+      let shared = members.get(node.id.name);
+      if (!shared) {
+        shared = { parent: owner, owner: outer.owner, bindings: new Map(), types: new Set() };
+        members.set(node.id.name, shared);
+      }
+      const local: Scope = {
+        parent: shared,
+        owner: outer.owner,
+        bindings: new Map(),
+        types: new Set(),
+      };
+      scopes.set(node, outer);
+      scopes.set(node.body, local);
+      if (node.body.type === "TSModuleDeclaration") {
+        collect(node.body, local, shared);
+        return;
+      }
+      for (const statement of node.body.body) {
+        if (statement.type === "ExportNamedDeclaration" && statement.declaration) {
+          scopes.set(statement, local);
+          collect(statement.declaration, local, shared);
+        } else {
+          collect(statement, local);
+        }
+      }
+      return;
+    }
     const isFunction = [
       "FunctionDeclaration",
       "FunctionExpression",

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -61,7 +61,11 @@ export function createLocalEvidence(program: AnyNode) {
       });
       scope.bindings.set(pattern.name, bindings);
     } else if (pattern.type === "AssignmentPattern")
-      bind(pattern.left, scope, { kind: info.kind, annotation: info.annotation });
+      bind(pattern.left, scope, {
+        kind: info.kind,
+        annotation: info.annotation,
+        init: info.kind === "parameter" ? pattern.right : undefined,
+      });
     else if (pattern.type === "RestElement" || pattern.type === "TSParameterProperty")
       bind(pattern.argument ?? pattern.parameter, scope, {
         kind: info.kind,
@@ -269,6 +273,8 @@ export function createLocalEvidence(program: AnyNode) {
     if (node.type === "Identifier") {
       const target = binding(node);
       if (!target || target.written || seen.has(target)) return false;
+      if (target.kind === "parameter" && (target.init?.end ?? target.node.end) >= node.start)
+        return false;
       if (target.kind !== "parameter" && (!target.init || target.init.end >= node.start))
         return false;
       if (arrayType(target.annotation)) return true;

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -45,6 +45,7 @@ export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | 
 
 export function createLocalEvidence(program: AnyNode, { unwrapArrayAssertions = true } = {}) {
   const scopes = new WeakMap<object, Scope>();
+  const parents = new WeakMap<object, AnyNode>();
   const writes: AnyNode[] = [];
   const namespaces = new WeakMap<Scope, Map<string, Scope>>();
   const root: Scope = { owner: program, bindings: new Map(), types: new Set() };
@@ -208,7 +209,10 @@ export function createLocalEvidence(program: AnyNode, { unwrapArrayAssertions = 
       writes.push(node.left);
     for (const key of getNodeVisitorKeys(node)) {
       const value = node[key];
-      for (const child of Array.isArray(value) ? value : [value]) collect(child, scope);
+      for (const child of Array.isArray(value) ? value : [value]) {
+        if (child?.type) parents.set(child, node);
+        collect(child, scope);
+      }
     }
   }
   collect(program, root);
@@ -266,6 +270,37 @@ export function createLocalEvidence(program: AnyNode, { unwrapArrayAssertions = 
       return arrayType(node.typeAnnotation);
     return globalType(node, "Array") || globalType(node, "ReadonlyArray");
   }
+  function deferredParameterReference(node: AnyNode, owner: AnyNode): boolean {
+    for (let current = node; current && current !== owner; current = parents.get(current)) {
+      if (!["FunctionExpression", "ArrowFunctionExpression"].includes(current.type)) continue;
+      let value = current;
+      let parent = parents.get(value);
+      while (parent && expression(parent) === value) {
+        value = parent;
+        parent = parents.get(value);
+      }
+      // A function stored as a parameter default is not called by that initializer.
+      if (
+        parent?.type === "AssignmentPattern" &&
+        parent.right === value &&
+        parents.get(parent) === owner
+      )
+        return true;
+      // Unknown calls may invoke callbacks synchronously. Only known, unshadowed
+      // schedulers establish deferred execution without cross-function analysis.
+      if (
+        parent?.type === "CallExpression" &&
+        parent.arguments[0] === value &&
+        parent.callee.type === "Identifier" &&
+        ["setTimeout", "setInterval", "queueMicrotask", "requestAnimationFrame"].includes(
+          parent.callee.name,
+        ) &&
+        !binding(parent.callee)
+      )
+        return true;
+    }
+    return false;
+  }
   function isArray(node: AnyNode, seen = new Set<Binding>()): boolean {
     node = expression(node, unwrapArrayAssertions);
     if (!node) return false;
@@ -275,8 +310,8 @@ export function createLocalEvidence(program: AnyNode, { unwrapArrayAssertions = 
       if (!target || target.written || seen.has(target)) return false;
       if (
         target.kind === "parameter" &&
-        scopes.get(node)?.owner === target.owner &&
-        (target.init?.end ?? target.node.end) >= node.start
+        (target.init?.end ?? target.node.end) >= node.start &&
+        !deferredParameterReference(node, target.owner)
       )
         return false;
       if (target.kind !== "parameter" && (!target.init || target.init.end >= node.start))

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -58,7 +58,8 @@ export function createLocalEvidence(program: AnyNode) {
         owner: scope.owner,
       });
       scope.bindings.set(pattern.name, bindings);
-    } else if (pattern.type === "AssignmentPattern") bind(pattern.left, scope, { kind: info.kind });
+    } else if (pattern.type === "AssignmentPattern")
+      bind(pattern.left, scope, { kind: info.kind, annotation: info.annotation });
     else if (pattern.type === "RestElement" || pattern.type === "TSParameterProperty")
       bind(pattern.argument ?? pattern.parameter, scope, info);
     else if (pattern.type === "ArrayPattern")

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -9,7 +9,12 @@ type Binding = {
   written: boolean;
   owner: AnyNode;
 };
-type Scope = { parent?: Scope; owner: AnyNode; bindings: Map<string, Binding[]> };
+type Scope = {
+  parent?: Scope;
+  owner: AnyNode;
+  bindings: Map<string, Binding[]>;
+  types: Set<string>;
+};
 
 export function expression(node: AnyNode): AnyNode {
   while (
@@ -40,7 +45,7 @@ export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | 
 export function createLocalEvidence(program: AnyNode) {
   const scopes = new WeakMap<object, Scope>();
   const writes: AnyNode[] = [];
-  const root: Scope = { owner: program, bindings: new Map() };
+  const root: Scope = { owner: program, bindings: new Map(), types: new Set() };
   function bind(pattern: AnyNode, scope: Scope, info: Omit<Binding, "node" | "written" | "owner">) {
     if (!pattern) return;
     if (pattern.type === "Identifier") {
@@ -55,7 +60,7 @@ export function createLocalEvidence(program: AnyNode) {
       scope.bindings.set(pattern.name, bindings);
     } else if (pattern.type === "AssignmentPattern") bind(pattern.left, scope, { kind: info.kind });
     else if (pattern.type === "RestElement" || pattern.type === "TSParameterProperty")
-      bind(pattern.argument ?? pattern.parameter, scope, { kind: info.kind });
+      bind(pattern.argument ?? pattern.parameter, scope, info);
     else if (pattern.type === "ArrayPattern")
       for (const item of pattern.elements) bind(item, scope, { kind: info.kind });
     else if (pattern.type === "ObjectPattern")
@@ -80,6 +85,22 @@ export function createLocalEvidence(program: AnyNode) {
       ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
     )
       bind(node.local, outer, { kind: "other" });
+    if (
+      [
+        "ClassDeclaration",
+        "TSTypeAliasDeclaration",
+        "TSInterfaceDeclaration",
+        "TSEnumDeclaration",
+        "TSModuleDeclaration",
+        "TSImportEqualsDeclaration",
+      ].includes(node.type) &&
+      node.id?.name
+    )
+      outer.types.add(node.id.name);
+    if (
+      ["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)
+    )
+      outer.types.add(node.local.name);
     const isFunction = [
       "FunctionDeclaration",
       "FunctionExpression",
@@ -104,6 +125,7 @@ export function createLocalEvidence(program: AnyNode) {
           parent: outer,
           owner: isFunction ? node : outer.owner,
           bindings: new Map<string, Binding[]>(),
+          types: new Set<string>(),
         }
       : outer;
     if (isFunction) {
@@ -113,8 +135,11 @@ export function createLocalEvidence(program: AnyNode) {
     }
     if (node.type === "ClassExpression") bind(node.id, scope, { kind: "other" });
     if (node.type === "CatchClause") bind(node.param, scope, { kind: "other" });
-    for (const parameter of node.typeParameters?.params ?? [])
+    if (node.type === "ClassExpression" && node.id?.name) scope.types.add(node.id.name);
+    for (const parameter of node.typeParameters?.params ?? []) {
       bind(parameter.name, scope, { kind: "other" });
+      scope.types.add(parameter.name.name ?? parameter.name);
+    }
     scopes.set(node, scope);
     if (node.type === "VariableDeclaration") {
       let target = scope;
@@ -165,7 +190,9 @@ export function createLocalEvidence(program: AnyNode) {
       node.typeName.name !== name
     )
       return false;
-    return !binding(node.typeName);
+    for (let scope = scopes.get(node.typeName); scope; scope = scope.parent)
+      if (scope.types.has(name)) return false;
+    return true;
   }
   function broadType(node: AnyNode): boolean {
     if (!node) return false;
@@ -182,6 +209,7 @@ export function createLocalEvidence(program: AnyNode) {
     );
   }
   function arrayType(node: AnyNode): boolean {
+    if (node?.type === "TSParenthesizedType") return arrayType(node.typeAnnotation);
     if (node?.type === "TSArrayType" || node?.type === "TSTupleType") return true;
     if (node?.type === "TSTypeOperator" && node.operator === "readonly")
       return arrayType(node.typeAnnotation);
@@ -194,6 +222,8 @@ export function createLocalEvidence(program: AnyNode) {
     if (node.type === "Identifier") {
       const target = binding(node);
       if (!target || target.written || seen.has(target)) return false;
+      if (target.kind !== "parameter" && (!target.init || target.init.end >= node.start))
+        return false;
       if (arrayType(target.annotation)) return true;
       if (
         target.annotation ||

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -273,7 +273,11 @@ export function createLocalEvidence(program: AnyNode) {
     if (node.type === "Identifier") {
       const target = binding(node);
       if (!target || target.written || seen.has(target)) return false;
-      if (target.kind === "parameter" && (target.init?.end ?? target.node.end) >= node.start)
+      if (
+        target.kind === "parameter" &&
+        scopes.get(node)?.owner === target.owner &&
+        (target.init?.end ?? target.node.end) >= node.start
+      )
         return false;
       if (target.kind !== "parameter" && (!target.init || target.init.end >= node.start))
         return false;

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -91,7 +91,6 @@ export function createLocalEvidence(program: AnyNode) {
         "TSTypeAliasDeclaration",
         "TSInterfaceDeclaration",
         "TSEnumDeclaration",
-        "TSModuleDeclaration",
         "TSImportEqualsDeclaration",
       ].includes(node.type) &&
       node.id?.name

--- a/src/rule-packs/typescript/rules/local-evidence.ts
+++ b/src/rule-packs/typescript/rules/local-evidence.ts
@@ -43,7 +43,7 @@ export function arrayMethod(node: AnyNode): { object: AnyNode; name: string } | 
   return typeof name === "string" ? { object: expression(node.object), name } : null;
 }
 
-export function createLocalEvidence(program: AnyNode) {
+export function createLocalEvidence(program: AnyNode, { unwrapArrayAssertions = true } = {}) {
   const scopes = new WeakMap<object, Scope>();
   const writes: AnyNode[] = [];
   const namespaces = new WeakMap<Scope, Map<string, Scope>>();
@@ -267,7 +267,7 @@ export function createLocalEvidence(program: AnyNode) {
     return globalType(node, "Array") || globalType(node, "ReadonlyArray");
   }
   function isArray(node: AnyNode, seen = new Set<Binding>()): boolean {
-    node = expression(node);
+    node = expression(node, unwrapArrayAssertions);
     if (!node) return false;
     if (node.type === "ArrayExpression") return true;
     if (node.type === "Identifier") {

--- a/src/rule-packs/typescript/rules/no-array-filter-map.ts
+++ b/src/rule-packs/typescript/rules/no-array-filter-map.ts
@@ -35,7 +35,7 @@ export const noArrayFilterMap = createRule({
     return {
       ScriptNode(node: AnyNode) {
         if (node.type === "Program") {
-          evidence = createLocalEvidence(node);
+          evidence = createLocalEvidence(node, { unwrapArrayAssertions: false });
           return;
         }
         if (node.type !== "CallExpression" || node.optional) return;

--- a/src/rule-packs/typescript/rules/no-array-filter-map.ts
+++ b/src/rule-packs/typescript/rules/no-array-filter-map.ts
@@ -1,0 +1,63 @@
+import { createRule } from "../../../core/index.js";
+import { isTypeScriptSource, report, type AnyNode } from "./shared.js";
+import { arrayMethod, createLocalEvidence, expression } from "./local-evidence.js";
+
+const ruleId = "typescript/performance/no-array-filter-map";
+
+export const noArrayFilterMap = createRule({
+  meta: {
+    id: "typescript/performance/no-array-filter-map",
+    title: "Review adjacent eager array transformations",
+    description: "Detect adjacent filter/map or map/filter passes on locally evidenced arrays.",
+    why: "Adjacent eager passes allocate an intermediate array. This optional policy reports only array literals, direct array annotations, immutable aliases, and supported array-preserving calls. Imported factories, property types, and generic aliases are not inferred. Iterator helpers are not guaranteed faster.",
+    recommendedReplacement:
+      "Review a single transformation or supported iterator helpers, preserving callback order, indexes, thisArg, and sparse-array behavior. Check target runtime support before using iterator helpers.",
+    examples: [
+      {
+        title: "Review adjacent eager array transformations",
+        language: "ts",
+        invalid: "const values = [1, 2, 3].filter(value => value > 1).map(value => value * 2)",
+        valid:
+          "const values = [1, 2, 3].values().filter(value => value > 1).map(value => value * 2).toArray()",
+      },
+    ],
+    category: "performance",
+    severity: "warn",
+    fixable: "structural-review",
+    docsUrl:
+      "https://github.com/dmmulroy/anti-slop/tree/c44ef22ca116d0ba62a3ff663a0bd13a3f3fa40b#rules",
+    requires: { script: true },
+    aiGeneratedCodeRisk: "high",
+  },
+  create(ctx) {
+    if (!isTypeScriptSource(ctx)) return;
+    let evidence: ReturnType<typeof createLocalEvidence>;
+    return {
+      ScriptNode(node: AnyNode) {
+        if (node.type === "Program") {
+          evidence = createLocalEvidence(node);
+          return;
+        }
+        if (node.type !== "CallExpression" || node.optional) return;
+        const outer = arrayMethod(node.callee);
+        if (!outer || !["map", "filter"].includes(outer.name)) return;
+        const innerCall = expression(outer.object);
+        if (innerCall?.type !== "CallExpression" || innerCall.optional) return;
+        const inner = arrayMethod(innerCall.callee);
+        if (
+          !inner ||
+          inner.name !== (outer.name === "map" ? "filter" : "map") ||
+          !evidence.isArray(inner.object)
+        )
+          return;
+        report(
+          ctx,
+          node,
+          ruleId,
+          "These adjacent eager array passes allocate an intermediate array.",
+          "Review a single transformation or supported iterator helpers. Preserve callback order, indexes, thisArg, and sparse-array behavior; measure performance before changing the pipeline.",
+        );
+      },
+    };
+  },
+});

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -19,6 +19,32 @@ test("array-pass reports expose the diagnostic code and reference", () => {
 
 const cases: [string, string, number][] = [
   [
+    "merged namespace exported class",
+    "export {}; namespace Local { export class Array<T> {} } namespace Local { namespace Array {} function f(values: Array<number>) { return values.filter(keep).map(transform) } }",
+    0,
+  ],
+  [
+    "merged namespace forward exported interface",
+    "export {}; namespace Local { function f(values: ReadonlyArray<number>) { return values.filter(keep).map(transform) } } namespace Local { export interface ReadonlyArray<T> { custom: T } }",
+    0,
+  ],
+  [
+    "merged namespace private type stays local",
+    "export {}; namespace Local { class Array<T> {} } namespace Local { function f(values: Array<number>) { return values.filter(keep).map(transform) } }",
+    1,
+  ],
+  [
+    "distinct namespace types stay local",
+    "export {}; namespace First { export class Array<T> {} } namespace Second { function f(values: Array<number>) { return values.filter(keep).map(transform) } }",
+    1,
+  ],
+  [
+    "nested merged namespace exported type",
+    "export {}; namespace Local.Inner { export class Array<T> {} } namespace Local.Inner { function f(values: Array<number>) { return values.filter(keep).map(transform) } }",
+    0,
+  ],
+
+  [
     "value Array parameter",
     "function f(Array: unknown, values: Array<number>) { return values.filter(keep).map(transform) }",
     1,
@@ -201,7 +227,7 @@ test("reports TypeScript Vue scripts with source locations", async () => {
     files: {
       "App.vue":
         '<template><p>Example</p></template>\n<script setup lang="ts">\n' +
-        cases[0]![1] +
+        "function f(values: number[]) { return values.filter(keep).map(transform) }" +
         "\n</script>",
     },
   });

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -30,6 +30,26 @@ const cases: [string, string, number][] = [
     0,
   ],
   [
+    "namespace Array preserves global type",
+    "export {}; namespace Local { namespace Array { export const value = 1 } function f(values: Array<number>) { return values.filter(keep).map(transform) } }",
+    1,
+  ],
+  [
+    "namespace ReadonlyArray preserves global type",
+    "export {}; namespace Local { namespace ReadonlyArray { export const value = 1 } function f(values: ReadonlyArray<number>) { return values.filter(keep).map(transform) } }",
+    1,
+  ],
+  [
+    "namespace merged with class still shadows type",
+    "export {}; class Array<T> {} namespace Array { export const value = 1 } function f(values: Array<number>) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "namespace merged with interface still shadows type",
+    "export {}; interface ReadonlyArray<T> { custom: T } namespace ReadonlyArray { export const value = 1 } function f(values: ReadonlyArray<number>) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
     "rest array",
     "function f(...values: number[]) { return values.filter(keep).map(transform) }",
     1,

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -19,6 +19,21 @@ test("array-pass reports expose the diagnostic code and reference", () => {
 
 const cases: [string, string, number][] = [
   [
+    "default callback retains parameter evidence",
+    "function f(values: number[] = (setTimeout(() => values.filter(keep).map(transform), 0), [])) {}",
+    1,
+  ],
+  [
+    "default function callback retains parameter evidence",
+    "function f(values: number[] = (setTimeout(function () { return values.map(transform).filter(keep) }, 0), [])) {}",
+    1,
+  ],
+  [
+    "earlier default callback retains later parameter evidence",
+    "function f(callback = () => values.filter(keep).map(transform), values: number[] = []) {}",
+    1,
+  ],
+  [
     "parameter is unavailable in its own default",
     "function f(values: number[] = values.filter(keep).map(transform)) {}",
     0,

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -50,6 +50,21 @@ const cases: [string, string, number][] = [
     0,
   ],
   [
+    "defaulted array parameter",
+    "function f(values: number[] = []) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "defaulted tuple parameter",
+    "function f(values: [number] = [1]) { return values.map(transform).filter(keep) }",
+    1,
+  ],
+  [
+    "defaulted destructured element is not an array",
+    "function f([value = 1]: number[] = []) { return value.filter(keep).map(transform) }",
+    0,
+  ],
+  [
     "rest array",
     "function f(...values: number[]) { return values.filter(keep).map(transform) }",
     1,

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -1,7 +1,21 @@
 import { expect, test } from "vite-plus/test";
 import { runProjectFixture } from "../../../src/core/testkit.js";
+import { createRulesReport, explainRule } from "../../../src/core/reports.js";
 import { noArrayFilterMap, typescriptRulePack } from "../../../src/rule-packs/typescript/index.js";
 import { getRuleDocuments, getDiagnosticDocuments } from "../../../docs/rules/source.js";
+
+test("array-pass reports expose the diagnostic code and reference", () => {
+  const id = noArrayFilterMap.meta.id;
+  const report = JSON.parse(createRulesReport([typescriptRulePack], "json"));
+  expect(report.rules.find((rule: { id: string }) => rule.id === id).diagnosticCodes).toEqual([
+    "TS0012",
+  ]);
+  const explanation = JSON.parse(explainRule([typescriptRulePack], id, "json"));
+  expect(explanation.diagnosticCodes).toEqual(["TS0012"]);
+  expect(explanation.diagnostics).toEqual([
+    { code: "TS0012", docs: "https://vite-doctor.onmax.me/diagnostics/TS0012" },
+  ]);
+});
 
 const cases: [string, string, number][] = [
   [

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -4,6 +4,64 @@ import { noArrayFilterMap, typescriptRulePack } from "../../../src/rule-packs/ty
 import { getRuleDocuments, getDiagnosticDocuments } from "../../../docs/rules/source.js";
 
 const cases: [string, string, number][] = [
+  [
+    "value Array parameter",
+    "function f(Array: unknown, values: Array<number>) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "value ReadonlyArray declaration",
+    "const ReadonlyArray = 1; function f(values: ReadonlyArray<number>) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "outer type shadow with inner value",
+    "type Array<T> = Custom; function f(Array: unknown, values: Array<number>) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "generic Array shadow",
+    "function f<Array>(values: Array<number>) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "class Array shadow",
+    "class Array<T> {} function f(values: Array<number>) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "rest array",
+    "function f(...values: number[]) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "rest tuple",
+    "function f(...values: [number, number]) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "parenthesized array",
+    "function f(values: (number[])) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "parenthesized tuple",
+    "function f(values: ([number])) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "annotated hoisted var",
+    "function f() { values.filter(keep).map(transform); var values: number[] = input }",
+    0,
+  ],
+  ["uninitialized local", "let values: number[]; values.filter(keep).map(transform)", 0],
+  [
+    "initialized annotated local",
+    "const values: number[] = input; values.filter(keep).map(transform)",
+    1,
+  ],
+  ["self initializer", "const values: number[] = values.filter(keep).map(transform)", 0],
+
   ["literal", "[1, 2].filter(keep).map(transform)", 1],
   ["reverse", "[1, 2].map(transform).filter(keep)", 1],
   ["const alias", "const values = [1]; const alias = values; alias.filter(keep).map(transform)", 1],

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -19,6 +19,37 @@ test("array-pass reports expose the diagnostic code and reference", () => {
 
 const cases: [string, string, number][] = [
   [
+    "immediately invoked default arrow has no parameter evidence",
+    "function f(values: number[] = (() => values.filter(keep).map(transform))()) {}",
+    0,
+  ],
+  [
+    "immediately invoked default function has no parameter evidence",
+    "function f(values: number[] = (function () { return values.map(transform).filter(keep) })()) {}",
+    0,
+  ],
+  [
+    "synchronous array callback has no parameter evidence",
+    "function f(values: number[] = [1].flatMap(() => values.filter(keep).map(transform))) {}",
+    0,
+  ],
+  [
+    "unknown callback timing has no parameter evidence",
+    "function f(values: number[] = invoke(() => values.filter(keep).map(transform))) {}",
+    0,
+  ],
+  [
+    "shadowed scheduler has no parameter evidence",
+    "function f(setTimeout: Function, values: number[] = setTimeout(() => values.filter(keep).map(transform))) {}",
+    0,
+  ],
+  [
+    "deferred callback inside an IIFE retains parameter evidence",
+    "function f(values: number[] = (() => { queueMicrotask(() => values.filter(keep).map(transform)); return [] })()) {}",
+    1,
+  ],
+
+  [
     "default callback retains parameter evidence",
     "function f(values: number[] = (setTimeout(() => values.filter(keep).map(transform), 0), [])) {}",
     1,

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -19,6 +19,31 @@ test("array-pass reports expose the diagnostic code and reference", () => {
 
 const cases: [string, string, number][] = [
   [
+    "parameter is unavailable in its own default",
+    "function f(values: number[] = values.filter(keep).map(transform)) {}",
+    0,
+  ],
+  [
+    "defaulted parameter is available in the body",
+    "function f(values: number[] = values.filter(keep).map(transform)) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "later parameter is unavailable in an earlier default",
+    "function f(result = values.filter(keep).map(transform), values: number[]) {}",
+    0,
+  ],
+  [
+    "earlier parameter is available in a later default",
+    "function f(values: number[] = [], result = values.filter(keep).map(transform)) {}",
+    1,
+  ],
+  [
+    "arrow parameter is unavailable in its own default",
+    "const f = (values: number[] = values.map(transform).filter(keep)) => values.map(transform).filter(keep)",
+    1,
+  ],
+  [
     "merged namespace exported class",
     "export {}; namespace Local { export class Array<T> {} } namespace Local { namespace Array {} function f(values: Array<number>) { return values.filter(keep).map(transform) } }",
     0,

--- a/tests/rule-packs/typescript/array-filter-map.test.ts
+++ b/tests/rule-packs/typescript/array-filter-map.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "vite-plus/test";
+import { runProjectFixture } from "../../../src/core/testkit.js";
+import { noArrayFilterMap, typescriptRulePack } from "../../../src/rule-packs/typescript/index.js";
+import { getRuleDocuments, getDiagnosticDocuments } from "../../../docs/rules/source.js";
+
+const cases: [string, string, number][] = [
+  ["literal", "[1, 2].filter(keep).map(transform)", 1],
+  ["reverse", "[1, 2].map(transform).filter(keep)", 1],
+  ["const alias", "const values = [1]; const alias = values; alias.filter(keep).map(transform)", 1],
+  [
+    "typed parameter",
+    "function f(values: number[]) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "readonly array",
+    "function f(values: ReadonlyArray<number>) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  [
+    "readonly tuple",
+    "function f(values: readonly [number, number]) { return values.filter(keep).map(transform) }",
+    1,
+  ],
+  ["array chain", "[1, 2].slice().filter(keep).map(transform)", 1],
+  ["computed method", "[1, 2]['filter'](keep)['map'](transform)", 1],
+  ["iterator", "[1, 2].values().filter(keep).map(transform).toArray()", 0],
+  ["factory", "loadValues().filter(keep).map(transform)", 0],
+  ["untyped parameter", "function f(values) { return values.filter(keep).map(transform) }", 0],
+  [
+    "shadowed alias",
+    "const values = [1]; function f(values) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  ["reassigned alias", "let values = [1]; values = input; values.filter(keep).map(transform)", 0],
+  [
+    "type alias",
+    "type Values = number[]; function f(values: Values) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "shadowed Array",
+    "type Array<T> = Custom; function f(values: Array<number>) { return values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "member type",
+    "function f(value: { values: number[] }) { return value.values.filter(keep).map(transform) }",
+    0,
+  ],
+  ["asserted array", "(input as number[]).filter(keep).map(transform)", 0],
+  ["single pass", "[1, 2].flatMap(transform)", 0],
+  [
+    "loop shadowing",
+    "const values = [1]; for (const values of sources) { values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "catch shadowing",
+    "const values = [1]; try {} catch (values) { values.filter(keep).map(transform) }",
+    0,
+  ],
+  [
+    "var hoisting",
+    "const values = [1]; function f() { values.filter(keep).map(transform); if (ready) { var values = input } }",
+    0,
+  ],
+];
+
+test.each(cases)("checks %s", async (_name, source, expected) => {
+  const result = await runProjectFixture({
+    framework: "vite",
+    rules: [noArrayFilterMap],
+    files: { "index.ts": source },
+  });
+  expect(result.diagnostics.map((item) => item.code)).toEqual(Array(expected).fill("TS0012"));
+});
+
+test("exports an opt-in rule with generated rule and diagnostic documentation", () => {
+  expect(typescriptRulePack.presets.strict).toContain(noArrayFilterMap.meta.id);
+  expect(typescriptRulePack.presets.recommended).not.toContain(noArrayFilterMap.meta.id);
+  expect(
+    getRuleDocuments().find((rule) => rule.id === noArrayFilterMap.meta.id)?.examples.length,
+  ).toBeGreaterThan(0);
+  expect(getDiagnosticDocuments().find((diagnostic) => diagnostic.code === "TS0012")?.ruleId).toBe(
+    noArrayFilterMap.meta.id,
+  );
+});
+
+test("reports TypeScript Vue scripts with source locations", async () => {
+  const result = await runProjectFixture({
+    rules: [noArrayFilterMap],
+    files: {
+      "App.vue":
+        '<template><p>Example</p></template>\n<script setup lang="ts">\n' +
+        cases[0]![1] +
+        "\n</script>",
+    },
+  });
+  expect(result.diagnostics.map((item) => item.code)).toEqual(["TS0012"]);
+  expect(result.diagnostics[0]?.range?.line).toBe(3);
+});
+
+test("leaves JavaScript-only sources outside the TypeScript Rule Pack", async () => {
+  const result = await runProjectFixture({
+    framework: "vite",
+    rules: [noArrayFilterMap],
+    files: {
+      "index.js":
+        "const values = [1]; values.filter(keep).map(transform); values.reduce((acc, item) => acc.concat(item), [])",
+    },
+  });
+  expect(result.diagnostics).toHaveLength(0);
+});

--- a/tests/rule-packs/typescript/reduce-copy.test.ts
+++ b/tests/rule-packs/typescript/reduce-copy.test.ts
@@ -89,6 +89,23 @@ const cases: [string, string, number][] = [
     "function f<Array>() {} const initial: Array<number> = value; items.reduce((acc, item) => acc.slice(), initial)",
     1,
   ],
+  ["asserted literal initializer", "items.reduce((acc, item) => acc.slice(), [] as number[])", 1],
+  ["angle asserted initializer", "items.reduce((acc, item) => acc.slice(), <number[]>[])", 1],
+  [
+    "asserted initializer alias",
+    "const initial = [] as number[]; items.reduce((acc, item) => acc.slice(), initial)",
+    1,
+  ],
+  [
+    "asserted initializer chain",
+    "items.reduce((acc, item) => acc.slice(), ([] as number[]).slice())",
+    1,
+  ],
+  [
+    "asserted unknown initializer",
+    "items.reduce((acc, item) => acc.slice(), input as number[])",
+    0,
+  ],
   ["concat", "items.reduce((acc, item) => acc.concat([item]), [])", 1],
   [
     "slice alias",


### PR DESCRIPTION
Adjacent eager filter/map passes allocate an intermediate array. Add an optional Strict Preset diagnostic for filter().map() and map().filter() when Doctor has local array evidence.

Recognizes array literals, direct array/tuple annotations, immutable local aliases, and supported array-preserving method chains. Iterator pipelines, unknown receivers, imported factories, property types, unresolved aliases, and asserted arrays are excluded. The diagnostic does not promise a speedup or autofix the pipeline: callback order, indexes, thisArg, sparse arrays, and iterator-helper runtime support require review.

Registers Diagnostic Code `TS0012`, public Rule Pack exports, rule metadata for generated Rule Catalog and Diagnostic Reference pages, and a changeset. Recommended Preset behavior remains unchanged; JavaScript-only sources stay outside the TypeScript Rule Pack.

The catalog test now compares documented rule IDs with registered rule IDs instead of fixing the TypeScript rule count at eight. The local-evidence helper is identical across the four new-rule PRs so it can be shared when they merge; each branch includes it and builds independently.

Validation: formatting, lint, declaration build, and all 420 tests passed across the runtime and documentation suites. The first full run exposed the obsolete catalog count; the corrected documentation suite passed on rerun. Tests include TypeScript Vue locations, shadowing, mutation/boundary exclusions, generated documentation, and preset selection. Built CLI probes verified explicit filtering within Strict, Strict alone, and unchanged Recommended behavior, including the diagnostic code, documentation URL, and source line.

Run this rule through the CLI Surface:

```sh
vite-doctor . --extends auto,vite-doctor/typescript/strict --rules typescript/performance/no-array-filter-map
```

Inspired by [anti-slop at c44ef22](https://github.com/dmmulroy/anti-slop/blob/c44ef22ca116d0ba62a3ff663a0bd13a3f3fa40b/src/rules/no-array-filter-map.ts). Doctor-native implementation; no Oxlint plugin dependency is added.

Independent branch from `main`; no other anti-slop PR is required.
